### PR TITLE
Use multi tenant provider (ILeagueProvider)

### DIFF
--- a/src/iRLeagueApiCore.Server/Controllers/ChampSeasonsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ChampSeasonsController.cs
@@ -23,17 +23,16 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Get single champSeason by id
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<ChampSeasonModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ChampSeasonModel>> Get([FromRoute] string leagueName, [FromRoute] long id, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetChampSeasonRequest(leagueId, id);
+        var request = new GetChampSeasonRequest(id);
         var getChampSeason = await mediator.Send(request, cancellationToken);
         return Ok(getChampSeason);
     }
@@ -42,17 +41,16 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Get all champSeasons from a championship
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Championships/{id:long}/ChampSeasons")]
-    public async Task<ActionResult<IEnumerable<ChampSeasonModel>>> GetFromChampionship([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<IEnumerable<ChampSeasonModel>>> GetFromChampionship([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken = default)
     {
-        var request = new GetChampSeasonsFromChampionshipRequest(leagueId, id);
+        var request = new GetChampSeasonsFromChampionshipRequest(id);
         var getChampSeasons = await mediator.Send(request, cancellationToken);
         return Ok(getChampSeasons);
     }
@@ -61,17 +59,16 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Get all champSeasons from a season
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Seasons/{id:long}/ChampSeasons")]
-    public async Task<ActionResult<IEnumerable<ChampSeasonModel>>> GetFromSeason([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<IEnumerable<ChampSeasonModel>>> GetFromSeason([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken = default)
     {
-        var request = new GetChampSeasonsFromSeasonRequest(leagueId, id);
+        var request = new GetChampSeasonsFromSeasonRequest(id);
         var getChampSeasons = await mediator.Send(request, cancellationToken);
         return Ok(getChampSeasons);
     }
@@ -80,17 +77,16 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Get a single champseason from a season and championship
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="championshipId"></param>
     /// <param name="seasonId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [Route("/{leagueName}/Seasons/{seasonId:long}/Championships/{championshipId:long}")]
-    public async Task<ActionResult<ChampSeasonModel>> GetFromSeasonAndChampionship([FromRoute] string leagueName, [FromFilter] long leagueId, 
-        [FromRoute] long championshipId, [FromRoute] long seasonId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ChampSeasonModel>> GetFromSeasonAndChampionship([FromRoute] string leagueName, [FromRoute] long championshipId,
+        [FromRoute] long seasonId, CancellationToken cancellationToken = default)
     {
-        var request = new GetChampSeasonFromSeasonChampionshipRequest(leagueId, seasonId, championshipId);
+        var request = new GetChampSeasonFromSeasonChampionshipRequest(seasonId, championshipId);
         var getChampSeason = await mediator.Send(request, cancellationToken);
         return Ok(getChampSeason);
     }
@@ -99,7 +95,6 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Post a new champSeason for a championship to the selected season
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="championshipId"></param>
     /// <param name="seasonId"></param>
     /// <param name="postChampSeason"></param>
@@ -107,11 +102,11 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// <returns></returns>
     [HttpPost]
     [Route("/{leagueName}/Seasons/{seasonId:long}/Championships/{championshipId:long}")]
-    public async Task<ActionResult<ChampSeasonModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long championshipId, [FromRoute] long seasonId, 
+    public async Task<ActionResult<ChampSeasonModel>> Post([FromRoute] string leagueName, [FromRoute] long championshipId, [FromRoute] long seasonId, 
         [FromBody] PostChampSeasonModel postChampSeason, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostChampSeasonRequest(leagueId, championshipId, seasonId, leagueUser, postChampSeason);
+        var request = new PostChampSeasonRequest(championshipId, seasonId, leagueUser, postChampSeason);
         var getChampSeason = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getChampSeason.ChampSeasonId }, getChampSeason);
     }
@@ -120,7 +115,6 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Update a single champSeason
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="putChampSeason"></param>
     /// <param name="cancellationToken"></param>
@@ -128,11 +122,11 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     [HttpPut]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("{id:long}")]
-    public async Task<ActionResult<ChampSeasonModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId,
-    [FromRoute] long id, [FromBody] PutChampSeasonModel putChampSeason, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ChampSeasonModel>> Put([FromRoute] string leagueName, [FromRoute] long id, 
+        [FromBody] PutChampSeasonModel putChampSeason, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutChampSeasonRequest(leagueId, id, leagueUser, putChampSeason);
+        var request = new PutChampSeasonRequest(id, leagueUser, putChampSeason);
         var getChampSeason = await mediator.Send(request, cancellationToken);
         return Ok(getChampSeason);
     }
@@ -141,17 +135,15 @@ public class ChampSeasonsController : LeagueApiController<ChampSeasonsController
     /// Delete a champSeason permanently
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin)]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        var request = new DeleteChampSeasonRequest(leagueId, id);
+        var request = new DeleteChampSeasonRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/ChampSeasonsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ChampSeasonsController.cs
@@ -9,7 +9,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 
 [Authorize]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public class ChampSeasonsController : LeagueApiController<ChampSeasonsController>

--- a/src/iRLeagueApiCore.Server/Controllers/ChampionshipsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ChampionshipsController.cs
@@ -10,7 +10,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 
 [Authorize]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public class ChampionshipsController : LeagueApiController<ChampionshipsController>

--- a/src/iRLeagueApiCore.Server/Controllers/ChampionshipsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ChampionshipsController.cs
@@ -24,17 +24,16 @@ public class ChampionshipsController : LeagueApiController<ChampionshipsControll
     /// Get single championship by id
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<ChampionshipModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ChampionshipModel>> Get([FromRoute] string leagueName, [FromRoute] long id, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetChampionshipRequest(leagueId, id);
+        var request = new GetChampionshipRequest(id);
         var getChampionship = await mediator.Send(request, cancellationToken);
         return Ok(getChampionship);
     }
@@ -43,15 +42,15 @@ public class ChampionshipsController : LeagueApiController<ChampionshipsControll
     /// Get all championships from a league
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("")]
-    public async Task<ActionResult<IEnumerable<ChampionshipModel>>> GetFromLeague([FromRoute] string leagueName, [FromFilter] long leagueId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<ChampionshipModel>>> GetFromLeague([FromRoute] string leagueName, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetChampionshipsFromLeagueRequest(leagueId);
+        var request = new GetChampionshipsFromLeagueRequest();
         var getChampionships = await mediator.Send(request, cancellationToken);
         return Ok(getChampionships);
     }
@@ -60,17 +59,16 @@ public class ChampionshipsController : LeagueApiController<ChampionshipsControll
     /// Post a new championship
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="postChampionship"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpPost]
     [Route("")]
-    public async Task<ActionResult<ChampionshipModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId, [FromBody] PostChampionshipModel postChampionship,
+    public async Task<ActionResult<ChampionshipModel>> Post([FromRoute] string leagueName, [FromBody] PostChampionshipModel postChampionship,
         CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostChampionshipRequest(leagueId, leagueUser, postChampionship);
+        var request = new PostChampionshipRequest(leagueUser, postChampionship);
         var getChampionship = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getChampionship.ChampionshipId }, getChampionship);
     }
@@ -79,7 +77,6 @@ public class ChampionshipsController : LeagueApiController<ChampionshipsControll
     /// Update a single championship
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="putChampionship"></param>
     /// <param name="cancellationToken"></param>
@@ -87,11 +84,11 @@ public class ChampionshipsController : LeagueApiController<ChampionshipsControll
     [HttpPut]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("{id:long}")]
-    public async Task<ActionResult<ChampionshipModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId,
-    [FromRoute] long id, [FromBody] PutChampionshipModel putChampionship, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ChampionshipModel>> Put([FromRoute] string leagueName, [FromRoute] long id, 
+        [FromBody] PutChampionshipModel putChampionship, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutChampionshipRequest(leagueId, id, leagueUser, putChampionship);
+        var request = new PutChampionshipRequest(id, leagueUser, putChampionship);
         var getChampionship = await mediator.Send(request, cancellationToken);
         return Ok(getChampionship);
     }
@@ -100,17 +97,16 @@ public class ChampionshipsController : LeagueApiController<ChampionshipsControll
     /// Delete a championship permanently
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin)]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new DeleteChampionshipRequest(leagueId, id);
+        var request = new DeleteChampionshipRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/EventsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/EventsController.cs
@@ -24,10 +24,10 @@ public sealed class EventsController : LeagueApiController<EventsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<EventModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, [FromQuery] bool includeDetails = false, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<EventModel>> Get([FromRoute] string leagueName, [FromRoute] long id, [FromQuery] bool includeDetails = false, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetEventRequest(leagueId, id, includeDetails);
+        var request = new GetEventRequest(id, includeDetails);
         var getEvent = await mediator.Send(request, cancellationToken);
         return Ok(getEvent);
     }
@@ -35,10 +35,10 @@ public sealed class EventsController : LeagueApiController<EventsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Schedules/{scheduleId:long}/Events")]
-    public async Task<ActionResult<IEnumerable<EventModel>>> GetFromSchedule([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long scheduleId, [FromQuery] bool includeDetails = false, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<EventModel>>> GetFromSchedule([FromRoute] string leagueName, [FromRoute] long scheduleId, [FromQuery] bool includeDetails = false, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetEventsFromScheduleRequest(leagueId, scheduleId, includeDetails);
+        var request = new GetEventsFromScheduleRequest(scheduleId, includeDetails);
         var getEvents = await mediator.Send(request, cancellationToken);
         return Ok(getEvents);
     }
@@ -46,10 +46,10 @@ public sealed class EventsController : LeagueApiController<EventsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Seasons/{seasonId:long}/Events")]
-    public async Task<ActionResult<IEnumerable<EventModel>>> GetFromSeason([FromRoute] string leagueName, [FromFilter] long leagueId,
+    public async Task<ActionResult<IEnumerable<EventModel>>> GetFromSeason([FromRoute] string leagueName,
         [FromRoute] long seasonId, [FromQuery] bool includeDetails = false, CancellationToken cancellationToken = default)
     {
-        var request = new GetEventsFromSeasonRequest(leagueId, seasonId, includeDetails);
+        var request = new GetEventsFromSeasonRequest(seasonId, includeDetails);
         var getSessions = await mediator.Send(request, cancellationToken);
         return Ok(getSessions);
     }
@@ -57,11 +57,11 @@ public sealed class EventsController : LeagueApiController<EventsController>
     [HttpPost]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("/{leagueName}/Schedules/{scheduleId:long}/Events")]
-    public async Task<ActionResult<EventModel>> PostToSchedule([FromRoute] string leagueName, [FromFilter] long leagueId,
+    public async Task<ActionResult<EventModel>> PostToSchedule([FromRoute] string leagueName,
         [FromRoute] long scheduleId, [FromBody] PostEventModel postEvent, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostEventToScheduleRequest(leagueId, scheduleId, leagueUser, postEvent);
+        var request = new PostEventToScheduleRequest(scheduleId, leagueUser, postEvent);
         var getEvent = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getEvent.Id }, getEvent);
     }
@@ -69,11 +69,11 @@ public sealed class EventsController : LeagueApiController<EventsController>
     [HttpPut]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("{id:long}")]
-    public async Task<ActionResult<EventModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId,
+    public async Task<ActionResult<EventModel>> Put([FromRoute] string leagueName,
         [FromRoute] long id, [FromBody] PutEventModel putEvent, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutEventRequest(leagueId, id, leagueUser, putEvent);
+        var request = new PutEventRequest(id, leagueUser, putEvent);
         var getEvent = await mediator.Send(request, cancellationToken);
         return Ok(getEvent);
     }
@@ -81,10 +81,10 @@ public sealed class EventsController : LeagueApiController<EventsController>
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin)]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName,
         [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        var request = new DeleteEventRequest(leagueId, id);
+        var request = new DeleteEventRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/EventsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/EventsController.cs
@@ -12,7 +12,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 /// </summary>
 [Authorize]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class EventsController : LeagueApiController<EventsController>

--- a/src/iRLeagueApiCore.Server/Controllers/MembersController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/MembersController.cs
@@ -22,10 +22,9 @@ public sealed class MembersController : LeagueApiController<MembersController>
 
     [HttpGet]
     [AllowAnonymous]
-    public async Task<ActionResult<IEnumerable<MemberInfoModel>>> GetFromLeague([FromRoute] string leagueName, [FromFilter] long leagueId,
-        CancellationToken cancellationToken)
+    public async Task<ActionResult<IEnumerable<MemberInfoModel>>> GetFromLeague([FromRoute] string leagueName, CancellationToken cancellationToken)
     {
-        var request = new GetMembersFromLeagueRequest(leagueId);
+        var request = new GetMembersFromLeagueRequest();
         var getMembers = await mediator.Send(request, cancellationToken);
         return Ok(getMembers);
     }
@@ -33,10 +32,10 @@ public sealed class MembersController : LeagueApiController<MembersController>
     [HttpGet]
     [Route("/{leagueName}/Events/{eventId:long}/[controller]")]
     [AllowAnonymous]
-    public async Task<ActionResult<IEnumerable<MemberInfoModel>>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long eventId,
+    public async Task<ActionResult<IEnumerable<MemberInfoModel>>> Get([FromRoute] string leagueName, [FromRoute] long eventId,
         CancellationToken cancellationToken)
     {
-        var request = new GetMembersFromEventRequest(leagueId, eventId);
+        var request = new GetMembersFromEventRequest(eventId);
         var getMembers = await mediator.Send(request, cancellationToken);
         return Ok(getMembers);
     }

--- a/src/iRLeagueApiCore.Server/Controllers/MembersController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/MembersController.cs
@@ -11,7 +11,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 /// </summary>
 [Authorize]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class MembersController : LeagueApiController<MembersController>

--- a/src/iRLeagueApiCore.Server/Controllers/PointRulesController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/PointRulesController.cs
@@ -18,10 +18,10 @@ public sealed class PointRulesController : LeagueApiController<PointRulesControl
 
     [HttpGet]
     [Route("{id:long}")]
-    public async Task<ActionResult<PointRuleModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<PointRuleModel>> Get([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new GetPointRuleRequest(leagueId, id);
+        var request = new GetPointRuleRequest(id);
         var getPointRule = await mediator.Send(request, cancellationToken);
         return Ok(getPointRule);
     }
@@ -29,11 +29,11 @@ public sealed class PointRulesController : LeagueApiController<PointRulesControl
     [HttpPost]
     [Route("")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<PointRuleModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId, PostPointRuleModel postPointRule,
+    public async Task<ActionResult<PointRuleModel>> Post([FromRoute] string leagueName, PostPointRuleModel postPointRule,
         CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostPointRuleRequest(leagueId, leagueUser, postPointRule);
+        var request = new PostPointRuleRequest(leagueUser, postPointRule);
         var getPointRule = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getPointRule.PointRuleId }, getPointRule);
     }
@@ -41,11 +41,11 @@ public sealed class PointRulesController : LeagueApiController<PointRulesControl
     [HttpPut]
     [Route("{id:long}")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<PointRuleModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<PointRuleModel>> Put([FromRoute] string leagueName, [FromRoute] long id,
         [FromBody] PutPointRuleModel putPointRule, CancellationToken cancellationToken)
     {
                 var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutPointRuleRequest(leagueId, id, leagueUser, putPointRule);
+        var request = new PutPointRuleRequest(id, leagueUser, putPointRule);
         var getPointRule = await mediator.Send(request, cancellationToken);
         _logger.LogInformation("Return entry for pointRule {PointRuleId} from {LeagueName}", getPointRule.PointRuleId, leagueName);
         return Ok(getPointRule);
@@ -54,10 +54,10 @@ public sealed class PointRulesController : LeagueApiController<PointRulesControl
     [HttpDelete]
     [Route("{id:long}")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeletePointRuleRequest(leagueId, id);
+        var request = new DeletePointRuleRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/PointRulesController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/PointRulesController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class PointRulesController : LeagueApiController<PointRulesController>

--- a/src/iRLeagueApiCore.Server/Controllers/ProtestsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ProtestsController.cs
@@ -20,11 +20,11 @@ public class ProtestsController : LeagueApiController<ProtestsController>
     [HttpPost]
     [AllowAnonymous]
     [Route("/{leagueName}/Sessions/{sessionId:long}/[controller]")]
-    public async Task<ActionResult<ProtestModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long sessionId,
-        PostProtestModel postReview, CancellationToken cancellationToken)
+    public async Task<ActionResult<ProtestModel>> Post([FromRoute] string leagueName, [FromRoute] long sessionId, PostProtestModel postReview, 
+        CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostProtestToSessionRequest(leagueId, sessionId, leagueUser, postReview);
+        var request = new PostProtestToSessionRequest(sessionId, leagueUser, postReview);
         var getProtest = await mediator.Send(request, cancellationToken);
         return Created(string.Empty, getProtest);
     }
@@ -32,11 +32,11 @@ public class ProtestsController : LeagueApiController<ProtestsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Events/{eventId:long}/Protests")]
-    public async Task<ActionResult<IEnumerable<ProtestModel>>> GetFromEvent([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long eventId, CancellationToken cancellationToken)
+    public async Task<ActionResult<IEnumerable<ProtestModel>>> GetFromEvent([FromRoute] string leagueName, [FromRoute] long eventId, 
+        CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new GetProtestsFromEventRequest(leagueId, leagueUser, eventId);
+        var request = new GetProtestsFromEventRequest(leagueUser, eventId);
         var getProtests = await mediator.Send(request, cancellationToken);
         return Ok(getProtests);
     }
@@ -44,10 +44,10 @@ public class ProtestsController : LeagueApiController<ProtestsController>
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Steward)]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeleteProtestRequest(leagueId, id);
+        var request = new DeleteProtestRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/ProtestsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ProtestsController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [Route("{leagueName}/[controller]")]
 public class ProtestsController : LeagueApiController<ProtestsController>
 {

--- a/src/iRLeagueApiCore.Server/Controllers/ResultConfigsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ResultConfigsController.cs
@@ -20,9 +20,9 @@ public sealed class ResultConfigsController : LeagueApiController<ResultConfigsC
     [HttpGet]
     [Route("")]
     [AllowAnonymous]
-    public async Task<ActionResult<IEnumerable<ResultConfigModel>>> GetAll([FromRoute] string leagueName, [FromFilter] long leagueId, CancellationToken cancellationToken)
+    public async Task<ActionResult<IEnumerable<ResultConfigModel>>> GetAll([FromRoute] string leagueName, CancellationToken cancellationToken)
     {
-        var request = new GetResultConfigsFromLeagueRequest(leagueId);
+        var request = new GetResultConfigsFromLeagueRequest();
         var getResultConfigs = await mediator.Send(request, cancellationToken);
         return Ok(getResultConfigs);
     }
@@ -30,10 +30,10 @@ public sealed class ResultConfigsController : LeagueApiController<ResultConfigsC
     [HttpGet]
     [Route("{id:long}")]
     [AllowAnonymous]
-    public async Task<ActionResult<ResultConfigModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ResultConfigModel>> Get([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new GetResultConfigRequest(leagueId, id);
+        var request = new GetResultConfigRequest(id);
         var getResultConfig = await mediator.Send(request, cancellationToken);
         return Ok(getResultConfig);
     }
@@ -41,10 +41,10 @@ public sealed class ResultConfigsController : LeagueApiController<ResultConfigsC
     [HttpGet]
     [Route("/{leagueName}/Seasons/{seasonId:long}/ResultConfigs")]
     [AllowAnonymous]
-    public async Task<ActionResult<ResultConfigModel>> GetFromSeason([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long seasonId,
+    public async Task<ActionResult<ResultConfigModel>> GetFromSeason([FromRoute] string leagueName, [FromRoute] long seasonId,
         CancellationToken cancellationToken)
     {
-        var request = new GetResultConfigsFromSeasonRequest(leagueId, seasonId);
+        var request = new GetResultConfigsFromSeasonRequest(seasonId);
         var getResultConfigs = await mediator.Send(request, cancellationToken);
         return Ok(getResultConfigs);
     }
@@ -52,11 +52,11 @@ public sealed class ResultConfigsController : LeagueApiController<ResultConfigsC
     [HttpPost]
     [Route("/{leagueName}/ChampSeasons/{champSeasonId:long}/ResultConfigs")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<ResultConfigModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long champSeasonId,
+    public async Task<ActionResult<ResultConfigModel>> Post([FromRoute] string leagueName, [FromRoute] long champSeasonId,
         [FromBody] PostResultConfigModel postResultConfig, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostResultConfigToChampSeasonRequest(leagueId, champSeasonId, leagueUser, postResultConfig);
+        var request = new PostResultConfigToChampSeasonRequest(champSeasonId, leagueUser, postResultConfig);
         var getResultConfig = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getResultConfig.ResultConfigId }, getResultConfig);
     }
@@ -64,11 +64,11 @@ public sealed class ResultConfigsController : LeagueApiController<ResultConfigsC
     [HttpPut]
     [Route("{id:long}")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<ResultConfigModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ResultConfigModel>> Put([FromRoute] string leagueName, [FromRoute] long id,
         [FromBody] PutResultConfigModel putResultConfig, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutResultConfigRequest(leagueId, id, leagueUser, putResultConfig);
+        var request = new PutResultConfigRequest(id, leagueUser, putResultConfig);
         var getResultConfig = await mediator.Send(request, cancellationToken);
         return Ok(getResultConfig);
     }
@@ -76,10 +76,10 @@ public sealed class ResultConfigsController : LeagueApiController<ResultConfigsC
     [HttpDelete]
     [Route("{id:long}")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeleteResultConfigRequest(leagueId, id);
+        var request = new DeleteResultConfigRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/ResultConfigsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ResultConfigsController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class ResultConfigsController : LeagueApiController<ResultConfigsController>

--- a/src/iRLeagueApiCore.Server/Controllers/ResultsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ResultsController.cs
@@ -21,17 +21,16 @@ public sealed class ResultsController : LeagueApiController<ResultsController>
     /// Get single result from specific resultId
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="resultId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<EventResultModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long resultId,
+    public async Task<ActionResult<EventResultModel>> Get([FromRoute] string leagueName, [FromRoute] long resultId,
         CancellationToken cancellationToken)
     {
-        var request = new GetResultRequest(leagueId, resultId);
+        var request = new GetResultRequest(resultId);
         var getResult = await mediator.Send(request, cancellationToken);
         return Ok(getResult);
     }
@@ -40,17 +39,16 @@ public sealed class ResultsController : LeagueApiController<ResultsController>
     /// Get all results from a season
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="seasonId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Seasons/{seasonId:long}/[controller]")]
-    public async Task<ActionResult<IEnumerable<SeasonEventResultModel>>> GetFromSeason([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long seasonId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<SeasonEventResultModel>>> GetFromSeason([FromRoute] string leagueName, [FromRoute] long seasonId,
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetResultsFromSeasonRequest(leagueId, seasonId);
+        var request = new GetResultsFromSeasonRequest(seasonId);
         var getResults = await mediator.Send(request, cancellationToken);
         return Ok(getResults);
     }
@@ -59,27 +57,26 @@ public sealed class ResultsController : LeagueApiController<ResultsController>
     /// Get all results from a session
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="eventId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Events/{eventId:long}/[controller]")]
-    public async Task<ActionResult<IEnumerable<EventResultModel>>> GetFromSession([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long eventId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<EventResultModel>>> GetFromSession([FromRoute] string leagueName, [FromRoute] long eventId, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetResultsFromEventRequest(leagueId, eventId);
+        var request = new GetResultsFromEventRequest(eventId);
         var getResults = await mediator.Send(request, cancellationToken);
         return Ok(getResults);
     }
 
     [HttpDelete]
     [Route("/{leagueName}/Events/{eventId:long}/[controller]")]
-    public async Task<ActionResult> DeleteFromEvent([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long eventId,
+    public async Task<ActionResult> DeleteFromEvent([FromRoute] string leagueName, [FromRoute] long eventId,
         CancellationToken cancellationToken = default)
     {
-        var request = new DeleteResultRequest(leagueId, eventId);
+        var request = new DeleteResultRequest(eventId);
         var getResults = await mediator.Send(request, cancellationToken);
         return NoContent();
     }
@@ -88,7 +85,6 @@ public sealed class ResultsController : LeagueApiController<ResultsController>
     /// Upload a result json (must be exported from the iRacing GUI)
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="eventId"></param>
     /// <param name="result">complete json data exported from iRacing GUI</param>
     /// <param name="cancellationToken"></param>
@@ -96,10 +92,10 @@ public sealed class ResultsController : LeagueApiController<ResultsController>
     [HttpPost]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("/{leagueName}/Events/{eventId:long}/[controller]/Upload")]
-    public async Task<ActionResult<bool>> UploadResult([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long eventId,
+    public async Task<ActionResult<bool>> UploadResult([FromRoute] string leagueName, [FromRoute] long eventId,
         [FromBody] ParseSimSessionResult result, CancellationToken cancellationToken = default)
     {
-        var request = new UploadResultRequest(leagueId, eventId, result);
+        var request = new UploadResultRequest(eventId, result);
         var success = await mediator.Send(request, cancellationToken);
         if (success)
         {
@@ -114,10 +110,10 @@ public sealed class ResultsController : LeagueApiController<ResultsController>
     [HttpPost]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("/{leagueName}/Events/{eventId:long}/[controller]/Calculate")]
-    public async Task<ActionResult<bool>> TriggerResultCalculation([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long eventId,
+    public async Task<ActionResult<bool>> TriggerResultCalculation([FromRoute] string leagueName, [FromRoute] long eventId,
         CancellationToken cancellationToken = default)
     {
-        var request = new TriggerResultCalculationCommand(leagueId, eventId);
+        var request = new TriggerResultCalculationCommand(eventId);
         await mediator.Send(request, cancellationToken);
         return Ok(true);
     }

--- a/src/iRLeagueApiCore.Server/Controllers/ResultsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ResultsController.cs
@@ -9,7 +9,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 
 [Route("/{leagueName}/[controller]")]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 public sealed class ResultsController : LeagueApiController<ResultsController>
 {

--- a/src/iRLeagueApiCore.Server/Controllers/ReviewCommentsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ReviewCommentsController.cs
@@ -18,10 +18,10 @@ public sealed class ReviewCommentsController : LeagueApiController<ReviewComment
 
     [HttpGet]
     [Route("{id:long}")]
-    public async Task<ActionResult<ReviewCommentModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ReviewCommentModel>> Get([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new GetReviewCommentRequest(leagueId, id);
+        var request = new GetReviewCommentRequest(id);
         var getReviewComment = await mediator.Send(request, cancellationToken);
         return Ok(getReviewComment);
     }
@@ -30,39 +30,38 @@ public sealed class ReviewCommentsController : LeagueApiController<ReviewComment
     /// Post new Comment to an existing review
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="reviewId"></param>
     /// <param name="postComment"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [HttpPost]
     [Route("/{leagueName}/Reviews/{reviewId:long}/[controller]")]
-    public async Task<ActionResult<ReviewCommentModel>> PostToReview([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long reviewId,
+    public async Task<ActionResult<ReviewCommentModel>> PostToReview([FromRoute] string leagueName, [FromRoute] long reviewId,
         [FromBody] PostReviewCommentModel postComment, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostReviewCommentToReviewRequest(leagueId, reviewId, leagueUser, postComment);
+        var request = new PostReviewCommentToReviewRequest(reviewId, leagueUser, postComment);
         var getComment = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getComment.CommentId }, getComment);
     }
 
     [HttpPut]
     [Route("{id:long}")]
-    public async Task<ActionResult<ReviewCommentModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ReviewCommentModel>> Put([FromRoute] string leagueName, [FromRoute] long id,
         PutReviewCommentModel putReviewComment, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutReviewCommentRequest(leagueId, id, leagueUser, putReviewComment);
+        var request = new PutReviewCommentRequest(id, leagueUser, putReviewComment);
         var getReviewComment = await mediator.Send(request, cancellationToken);
         return Ok(getReviewComment);
     }
 
     [HttpDelete]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeleteReviewCommentRequest(leagueId, id);
+        var request = new DeleteReviewCommentRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/ReviewCommentsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ReviewCommentsController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Steward)]
 [Route("{leagueName}/[controller]")]
 public sealed class ReviewCommentsController : LeagueApiController<ReviewCommentsController>

--- a/src/iRLeagueApiCore.Server/Controllers/ReviewsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ReviewsController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Steward)]
 [Route("{leagueName}/[controller]")]
 public sealed class ReviewsController : LeagueApiController<ReviewsController>

--- a/src/iRLeagueApiCore.Server/Controllers/ReviewsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ReviewsController.cs
@@ -25,43 +25,43 @@ public sealed class ReviewsController : LeagueApiController<ReviewsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<ReviewModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ReviewModel>> Get([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
         var includeComments = IncludeComments(new LeagueUser(leagueName, User));
-        var request = new GetReviewRequest(leagueId, id, includeComments);
+        var request = new GetReviewRequest(id, includeComments);
         var getReview = await mediator.Send(request, cancellationToken);
         return Ok(getReview);
     }
 
     [HttpPost]
     [Route("/{leagueName}/Sessions/{sessionId:long}/[controller]")]
-    public async Task<ActionResult<ReviewModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long sessionId,
+    public async Task<ActionResult<ReviewModel>> Post([FromRoute] string leagueName, [FromRoute] long sessionId,
         PostReviewModel postReview, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostReviewToSessionRequest(leagueId, sessionId, leagueUser, postReview);
+        var request = new PostReviewToSessionRequest(sessionId, leagueUser, postReview);
         var getReview = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getReview.ReviewId }, getReview);
     }
 
     [HttpPut]
     [Route("{id:long}")]
-    public async Task<ActionResult<ReviewModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ReviewModel>> Put([FromRoute] string leagueName, [FromRoute] long id,
         PutReviewModel putReview, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutReviewRequest(leagueId, id, leagueUser, putReview);
+        var request = new PutReviewRequest(id, leagueUser, putReview);
         var getReview = await mediator.Send(request, cancellationToken);
         return Ok(getReview);
     }
 
     [HttpDelete]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeleteReviewRequest(leagueId, id);
+        var request = new DeleteReviewRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }
@@ -69,11 +69,11 @@ public sealed class ReviewsController : LeagueApiController<ReviewsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Sessions/{sessionId:long}/Reviews")]
-    public async Task<ActionResult<IEnumerable<ReviewModel>>> GetFromSession([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long sessionId, CancellationToken cancellationToken)
+    public async Task<ActionResult<IEnumerable<ReviewModel>>> GetFromSession([FromRoute] string leagueName, [FromRoute] long sessionId, 
+        CancellationToken cancellationToken)
     {
         var includeComments = IncludeComments(new LeagueUser(leagueName, User));
-        var request = new GetReviewsFromSessionRequest(leagueId, sessionId, includeComments);
+        var request = new GetReviewsFromSessionRequest(sessionId, includeComments);
         var getReviews = await mediator.Send(request, cancellationToken);
         return Ok(getReviews);
     }
@@ -81,22 +81,22 @@ public sealed class ReviewsController : LeagueApiController<ReviewsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Events/{eventId:long}/Reviews")]
-    public async Task<ActionResult<IEnumerable<ReviewModel>>> GetFromEvent([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long eventId, CancellationToken cancellationToken)
+    public async Task<ActionResult<IEnumerable<ReviewModel>>> GetFromEvent([FromRoute] string leagueName, [FromRoute] long eventId, 
+        CancellationToken cancellationToken)
     {
         var includeComments = IncludeComments(new LeagueUser(leagueName, User));
-        var request = new GetReviewsFromEventRequest(leagueId, eventId, includeComments);
+        var request = new GetReviewsFromEventRequest(eventId, includeComments);
         var getReviews = await mediator.Send(request, cancellationToken);
         return Ok(getReviews);
     }
 
     [HttpPost]
     [Route("{id:long}/MoveToSession/{sessionId:long}")]
-    public async Task<ActionResult<ReviewModel>> MoveReviewToSession([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ReviewModel>> MoveReviewToSession([FromRoute] string leagueName, [FromRoute] long id,
         [FromRoute] long sessionId, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new MoveReviewToSessionRequest(leagueId, sessionId, id, leagueUser);
+        var request = new MoveReviewToSessionRequest(sessionId, id, leagueUser);
         var getReview = await mediator.Send(request, cancellationToken);
         return Ok(getReview);
     }

--- a/src/iRLeagueApiCore.Server/Controllers/SchedulesController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/SchedulesController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class SchedulesController : LeagueApiController<SchedulesController>

--- a/src/iRLeagueApiCore.Server/Controllers/SchedulesController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/SchedulesController.cs
@@ -19,10 +19,9 @@ public sealed class SchedulesController : LeagueApiController<SchedulesControlle
 
     [HttpGet]
     [Route("")]
-    public async Task<ActionResult<IEnumerable<ScheduleModel>>> GetAll([FromRoute] string leagueName, [FromFilter] long leagueId,
-        CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<ScheduleModel>>> GetAll([FromRoute] string leagueName, CancellationToken cancellationToken = default)
     {
-        var request = new GetSchedulesRequest(leagueId);
+        var request = new GetSchedulesRequest();
         var getSchedules = await mediator.Send(request, cancellationToken);
         return Ok(getSchedules);
     }
@@ -30,10 +29,10 @@ public sealed class SchedulesController : LeagueApiController<SchedulesControlle
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<ScheduleModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ScheduleModel>> Get([FromRoute] string leagueName, [FromRoute] long id, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetScheduleRequest(leagueId, id);
+        var request = new GetScheduleRequest(id);
         var getSchedule = await mediator.Send(request, cancellationToken);
         return Ok(getSchedule);
     }
@@ -41,10 +40,10 @@ public sealed class SchedulesController : LeagueApiController<SchedulesControlle
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Seasons/{seasonId:long}/[controller]")]
-    public async Task<ActionResult<IEnumerable<ScheduleModel>>> GetFromSeason([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long seasonId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<ScheduleModel>>> GetFromSeason([FromRoute] string leagueName, [FromRoute] long seasonId, 
+        CancellationToken cancellationToken = default)
     {
-        var request = new GetSchedulesFromSeasonRequest(leagueId, seasonId);
+        var request = new GetSchedulesFromSeasonRequest(seasonId);
         var getSchedules = await mediator.Send(request, cancellationToken);
         return Ok(getSchedules);
     }
@@ -52,11 +51,11 @@ public sealed class SchedulesController : LeagueApiController<SchedulesControlle
     [HttpPost]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("/{leagueName}/Seasons/{seasonId:long}/[controller]")]
-    public async Task<ActionResult<ScheduleModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long seasonId, [FromBody] PostScheduleModel postSchedule, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ScheduleModel>> Post([FromRoute] string leagueName, [FromRoute] long seasonId, [FromBody] PostScheduleModel postSchedule, 
+        CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostScheduleRequest(leagueId, seasonId, leagueUser, postSchedule);
+        var request = new PostScheduleRequest(seasonId, leagueUser, postSchedule);
         var getSchedule = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getSchedule.ScheduleId }, getSchedule);
     }
@@ -64,11 +63,11 @@ public sealed class SchedulesController : LeagueApiController<SchedulesControlle
     [HttpPut]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("{id:long}")]
-    public async Task<ActionResult<ScheduleModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, [FromBody] PutScheduleModel putSchedule, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ScheduleModel>> Put([FromRoute] string leagueName, [FromRoute] long id, [FromBody] PutScheduleModel putSchedule, 
+        CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutScheduleRequest(leagueId, leagueUser, id, putSchedule);
+        var request = new PutScheduleRequest(leagueUser, id, putSchedule);
         var getSchedule = await mediator.Send(request, cancellationToken);
         return Ok(getSchedule);
     }
@@ -76,10 +75,9 @@ public sealed class SchedulesController : LeagueApiController<SchedulesControlle
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin)]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        var request = new DeleteScheduleRequest(leagueId, id);
+        var request = new DeleteScheduleRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/ScoringsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ScoringsController.cs
@@ -20,68 +20,37 @@ public sealed class ScoringsController : LeagueApiController<ScoringsController>
     /// Get all scorings from league
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [Route("")]
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<ScoringModel>>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<ScoringModel>>> Get([FromRoute] string leagueName, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var request = new GetScoringsRequest(leagueId);
-            var getScorings = await mediator.Send(request, cancellationToken);
-            return Ok(getScorings);
-        }
-        catch (ValidationException ex)
-        {
-            _logger.LogInformation("Bad request - errors: {ValidationErrors}", ex.Errors.Select(x => x.ErrorMessage));
-            return ex.ToActionResult();
-        }
-        catch (ResourceNotFoundException)
-        {
-            _logger.LogInformation("Scorings not found in {LeagueName}", leagueName);
-            return NotFound();
-        }
+        var request = new GetScoringsRequest();
+        var getScorings = await mediator.Send(request, cancellationToken);
+        return Ok(getScorings);
     }
 
     /// <summary>
     /// Get scoring from league by Id
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [Route("{id:long}")]
     [HttpGet]
-    public async Task<ActionResult<ScoringModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ScoringModel>> Get([FromRoute] string leagueName, [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var request = new GetScoringRequest(leagueId, id);
-            var getScoring = await mediator.Send(request, cancellationToken);
-            return Ok(getScoring);
-        }
-        catch (ValidationException ex)
-        {
-            _logger.LogInformation("Bad request - errors: {ValidationErrors}", ex.Errors.Select(x => x.ErrorMessage));
-            return ex.ToActionResult();
-        }
-        catch (ResourceNotFoundException)
-        {
-            _logger.LogInformation("Scoring {ScoringId} not found in {LeagueName}", id, leagueName);
-            return NotFound();
-        }
+        var request = new GetScoringRequest(id);
+        var getScoring = await mediator.Send(request, cancellationToken);
+        return Ok(getScoring);
     }
 
     /// <summary>
     /// Update existing scoring with Id
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="model"></param>
     /// <param name="cancellationToken"></param>
@@ -89,57 +58,29 @@ public sealed class ScoringsController : LeagueApiController<ScoringsController>
     [Route("{id:long}")]
     [HttpPut]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<ScoringModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, [FromBody] PutScoringModel model, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<ScoringModel>> Put([FromRoute] string leagueName, [FromRoute] long id, [FromBody] PutScoringModel model, 
+        CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var leagueUser = new LeagueUser(leagueName, User);
-            var request = new PutScoringRequest(leagueId, id, leagueUser, model);
-            var getScoring = await mediator.Send(request, cancellationToken);
-            return Ok(getScoring);
-        }
-        catch (ValidationException ex)
-        {
-            _logger.LogInformation("Bad request - errors: {ValidationErrors}", ex.Errors.Select(x => x.ErrorMessage));
-            return ex.ToActionResult();
-        }
-        catch (ResourceNotFoundException)
-        {
-            _logger.LogInformation("Scoring {ScoringId} not found inside {LeagueName}", id, leagueName);
-            return NotFound();
-        }
+        var leagueUser = new LeagueUser(leagueName, User);
+        var request = new PutScoringRequest(id, leagueUser, model);
+        var getScoring = await mediator.Send(request, cancellationToken);
+        return Ok(getScoring);
     }
 
     /// <summary>
     /// Delete existing scoring with id
     /// </summary>
     /// <param name="leagueName"></param>
-    /// <param name="leagueId"></param>
     /// <param name="id"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     [Route("{id:long}")]
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var request = new DeleteScoringRequest(leagueId, id);
-            await mediator.Send(request, cancellationToken);
-            return NoContent();
-        }
-        catch (ValidationException ex)
-        {
-            _logger.LogInformation("Bad request - errors: {ValidationErrors}", ex.Errors.Select(x => x.ErrorMessage));
-            return ex.ToActionResult();
-        }
-        catch (ResourceNotFoundException)
-        {
-            _logger.LogInformation("Scoring {ScoringId} not found inside {LeagueName}", id, leagueName);
-            return NotFound();
-        }
+        var request = new DeleteScoringRequest(id);
+        await mediator.Send(request, cancellationToken);
+        return NoContent();
     }
 }

--- a/src/iRLeagueApiCore.Server/Controllers/ScoringsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/ScoringsController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class ScoringsController : LeagueApiController<ScoringsController>

--- a/src/iRLeagueApiCore.Server/Controllers/SeasonsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/SeasonsController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class SeasonsController : LeagueApiController<SeasonsController>

--- a/src/iRLeagueApiCore.Server/Controllers/SeasonsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/SeasonsController.cs
@@ -20,10 +20,9 @@ public sealed class SeasonsController : LeagueApiController<SeasonsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("")]
-    public async Task<ActionResult<IEnumerable<SeasonModel>>> GetAll([FromRoute] string leagueName, [FromFilter] long leagueId,
-        CancellationToken cancellationToken = default)
+    public async Task<ActionResult<IEnumerable<SeasonModel>>> GetAll([FromRoute] string leagueName, CancellationToken cancellationToken = default)
     {
-        var request = new GetSeasonsRequest(leagueId);
+        var request = new GetSeasonsRequest();
         var getSeasons = await mediator.Send(request, cancellationToken);
         return Ok(getSeasons);
     }
@@ -31,10 +30,9 @@ public sealed class SeasonsController : LeagueApiController<SeasonsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<SeasonModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<SeasonModel>> Get([FromRoute] string leagueName, [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        var request = new GetSeasonRequest(leagueId, id);
+        var request = new GetSeasonRequest(id);
         var getSeason = await mediator.Send(request, cancellationToken);
         return Ok(getSeason);
     }
@@ -42,9 +40,9 @@ public sealed class SeasonsController : LeagueApiController<SeasonsController>
     [HttpGet]
     [AllowAnonymous]
     [Route("Current")]
-    public async Task<ActionResult<SeasonModel>> GetCurrent([FromRoute] string leagueName, [FromFilter] long leagueId, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<SeasonModel>> GetCurrent([FromRoute] string leagueName, CancellationToken cancellationToken = default)
     {
-        var request = new GetCurrentSeasonRequest(leagueId);
+        var request = new GetCurrentSeasonRequest();
         var getSeason = await mediator.Send(request, cancellationToken);
         return Ok(getSeason);
     }
@@ -52,11 +50,10 @@ public sealed class SeasonsController : LeagueApiController<SeasonsController>
     [HttpPost]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("")]
-    public async Task<ActionResult<SeasonModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromBody] PostSeasonModel postSeason, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<SeasonModel>> Post([FromRoute] string leagueName, [FromBody] PostSeasonModel postSeason, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostSeasonRequest(leagueId, leagueUser, postSeason);
+        var request = new PostSeasonRequest(leagueUser, postSeason);
         var getSeason = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getSeason.SeasonId }, getSeason);
     }
@@ -64,11 +61,10 @@ public sealed class SeasonsController : LeagueApiController<SeasonsController>
     [HttpPut]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
     [Route("{id:long}")]
-    public async Task<ActionResult<SeasonModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, [FromBody] PutSeasonModel putSeason, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<SeasonModel>> Put([FromRoute] string leagueName, [FromRoute] long id, [FromBody] PutSeasonModel putSeason, CancellationToken cancellationToken = default)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutSeasonRequest(leagueId, leagueUser, id, putSeason);
+        var request = new PutSeasonRequest(leagueUser, id, putSeason);
         var getSeason = await mediator.Send(request, cancellationToken);
         return Ok(getSeason);
     }
@@ -76,10 +72,9 @@ public sealed class SeasonsController : LeagueApiController<SeasonsController>
     [HttpDelete]
     [RequireLeagueRole(LeagueRoles.Admin)]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId,
-        [FromRoute] long id, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id, CancellationToken cancellationToken = default)
     {
-        var request = new DeleteSeasonRequest(leagueId, id);
+        var request = new DeleteSeasonRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/StandingsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/StandingsController.cs
@@ -8,7 +8,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 
 [Route("/{leagueName}/[controller]")]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 public sealed class StandingsController : LeagueApiController<StandingsController>
 {

--- a/src/iRLeagueApiCore.Server/Controllers/StandingsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/StandingsController.cs
@@ -20,10 +20,10 @@ public sealed class StandingsController : LeagueApiController<StandingsControlle
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Seasons/{seasonId:long}/[controller]")]
-    public async Task<ActionResult<IEnumerable<StandingsModel>>> GetFromSeason([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long seasonId,
+    public async Task<ActionResult<IEnumerable<StandingsModel>>> GetFromSeason([FromRoute] string leagueName, [FromRoute] long seasonId,
         CancellationToken cancellationToken = default)
     {
-        var request = new GetStandingsFromSeasonRequest(leagueId, seasonId);
+        var request = new GetStandingsFromSeasonRequest(seasonId);
         var getStandings = await mediator.Send(request, cancellationToken);
         return Ok(getStandings);
     }
@@ -31,10 +31,10 @@ public sealed class StandingsController : LeagueApiController<StandingsControlle
     [HttpGet]
     [AllowAnonymous]
     [Route("/{leagueName}/Events/{eventId:long}/[controller]")]
-    public async Task<ActionResult<IEnumerable<StandingsModel>>> GetFromEvent([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long eventId,
+    public async Task<ActionResult<IEnumerable<StandingsModel>>> GetFromEvent([FromRoute] string leagueName, [FromRoute] long eventId,
         CancellationToken cancellationToken = default)
     {
-        var request = new GetStandingsFromEventRequest(leagueId, eventId);
+        var request = new GetStandingsFromEventRequest(eventId);
         var getStandings = await mediator.Send(request, cancellationToken);
         return Ok(getStandings);
     }

--- a/src/iRLeagueApiCore.Server/Controllers/TeamsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/TeamsController.cs
@@ -9,7 +9,7 @@ namespace iRLeagueApiCore.Server.Controllers;
 
 [Authorize]
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole]
 [Route("{leagueName}/[controller]")]
 public sealed class TeamsController : LeagueApiController<TeamsController>

--- a/src/iRLeagueApiCore.Server/Controllers/TeamsController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/TeamsController.cs
@@ -20,19 +20,19 @@ public sealed class TeamsController : LeagueApiController<TeamsController>
 
     [HttpGet]
     [Route("")]
-    public async Task<ActionResult<IEnumerable<TeamModel>>> GetAll([FromRoute] string leagueName, [FromFilter] long leagueId, CancellationToken cancellationToken)
+    public async Task<ActionResult<IEnumerable<TeamModel>>> GetAll([FromRoute] string leagueName, CancellationToken cancellationToken)
     {
-        var request = new GetTeamsFromLeagueRequest(leagueId);
+        var request = new GetTeamsFromLeagueRequest();
         var getTeams = await mediator.Send(request, cancellationToken);
         return Ok(getTeams);
     }
 
     [HttpGet]
     [Route("{id:long}")]
-    public async Task<ActionResult<TeamModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<TeamModel>> Get([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new GetTeamRequest(leagueId, id);
+        var request = new GetTeamRequest(id);
         var getTeam = await mediator.Send(request, cancellationToken);
         return Ok(getTeam);
     }
@@ -40,11 +40,11 @@ public sealed class TeamsController : LeagueApiController<TeamsController>
     [HttpPost]
     [Route("")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<TeamModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId,
+    public async Task<ActionResult<TeamModel>> Post([FromRoute] string leagueName,
         [FromBody] PostTeamModel postTeam, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PostTeamRequest(leagueId, leagueUser, postTeam);
+        var request = new PostTeamRequest(leagueUser, postTeam);
         var getTeam = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getTeam.TeamId }, getTeam);
     }
@@ -52,11 +52,11 @@ public sealed class TeamsController : LeagueApiController<TeamsController>
     [HttpPut]
     [Route("{id:long}")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult<TeamModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<TeamModel>> Put([FromRoute] string leagueName, [FromRoute] long id,
         [FromBody] PutTeamModel putTeam, CancellationToken cancellationToken)
     {
         var leagueUser = new LeagueUser(leagueName, User);
-        var request = new PutTeamRequest(leagueId, id, leagueUser, putTeam);
+        var request = new PutTeamRequest(id, leagueUser, putTeam);
         var getTeam = await mediator.Send(request, cancellationToken);
         return Ok(getTeam);
     }
@@ -64,10 +64,10 @@ public sealed class TeamsController : LeagueApiController<TeamsController>
     [HttpDelete]
     [Route("{id:long}")]
     [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Organizer)]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeleteTeamRequest(leagueId, id);
+        var request = new DeleteTeamRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Controllers/VoteCategoriesController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/VoteCategoriesController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace iRLeagueApiCore.Server.Controllers;
 
 [TypeFilter(typeof(LeagueAuthorizeAttribute))]
-[TypeFilter(typeof(InsertLeagueIdAttribute))]
+[TypeFilter(typeof(SetTenantLeagueIdAttribute))]
 [RequireLeagueRole(LeagueRoles.Admin, LeagueRoles.Steward)]
 [Route("{leagueName}/[controller]")]
 public sealed class VoteCategoriesController : LeagueApiController<VoteCategoriesController>

--- a/src/iRLeagueApiCore.Server/Controllers/VoteCategoriesController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/VoteCategoriesController.cs
@@ -21,10 +21,10 @@ public sealed class VoteCategoriesController : LeagueApiController<VoteCategorie
     [HttpGet]
     [AllowAnonymous]
     [Route("")]
-    public async Task<ActionResult<IEnumerable<VoteCategoryModel>>> GetAll([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<IEnumerable<VoteCategoryModel>>> GetAll([FromRoute] string leagueName, [FromRoute] long id,
             CancellationToken cancellationToken)
     {
-        var request = new GetLeagueVoteCategoriesRequest(leagueId);
+        var request = new GetLeagueVoteCategoriesRequest();
         var getVoteCategories = await mediator.Send(request, cancellationToken);
         return Ok(getVoteCategories);
     }
@@ -32,40 +32,40 @@ public sealed class VoteCategoriesController : LeagueApiController<VoteCategorie
     [HttpGet]
     [AllowAnonymous]
     [Route("{id:long}")]
-    public async Task<ActionResult<ReviewModel>> Get([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<ReviewModel>> Get([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new GetVoteCategoryRequest(leagueId, id);
+        var request = new GetVoteCategoryRequest(id);
         var getVoteCategory = await mediator.Send(request, cancellationToken);
         return Ok(getVoteCategory);
     }
 
     [HttpPost]
     [Route("")]
-    public async Task<ActionResult<VoteCategoryModel>> Post([FromRoute] string leagueName, [FromFilter] long leagueId,
+    public async Task<ActionResult<VoteCategoryModel>> Post([FromRoute] string leagueName,
         [FromBody] PostVoteCategoryModel postVoteCategory, CancellationToken cancellationToken)
     {
-        var request = new PostVoteCategoryRequest(leagueId, postVoteCategory);
+        var request = new PostVoteCategoryRequest(postVoteCategory);
         var getVoteCategory = await mediator.Send(request, cancellationToken);
         return CreatedAtAction(nameof(Get), new { leagueName, id = getVoteCategory.Id }, getVoteCategory);
     }
 
     [HttpPut]
     [Route("{id:long}")]
-    public async Task<ActionResult<VoteCategoryModel>> Put([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult<VoteCategoryModel>> Put([FromRoute] string leagueName, [FromRoute] long id,
         [FromBody] PutVoteCategoryModel putVoteCategory, CancellationToken cancellationToken)
     {
-        var request = new PutVoteCategoryRequest(leagueId, id, putVoteCategory);
+        var request = new PutVoteCategoryRequest(id, putVoteCategory);
         var getVoteCategory = await mediator.Send(request, cancellationToken);
         return Ok(getVoteCategory);
     }
 
     [HttpDelete]
     [Route("{id:long}")]
-    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromFilter] long leagueId, [FromRoute] long id,
+    public async Task<ActionResult> Delete([FromRoute] string leagueName, [FromRoute] long id,
         CancellationToken cancellationToken)
     {
-        var request = new DeleteVoteCategoryRequest(leagueId, id);
+        var request = new DeleteVoteCategoryRequest(id);
         await mediator.Send(request, cancellationToken);
         return NoContent();
     }

--- a/src/iRLeagueApiCore.Server/Filters/InsertLeagueIdAttribute.cs
+++ b/src/iRLeagueApiCore.Server/Filters/InsertLeagueIdAttribute.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace iRLeagueApiCore.Server.Filters;
@@ -23,9 +25,11 @@ namespace iRLeagueApiCore.Server.Filters;
 public sealed class InsertLeagueIdAttribute : ActionFilterAttribute
 {
     private readonly LeagueDbContext _dbContext;
-    public InsertLeagueIdAttribute(LeagueDbContext dbContext)
+    private readonly RequestLeagueProvider leagueProvider;
+    public InsertLeagueIdAttribute(LeagueDbContext dbContext, RequestLeagueProvider leagueProvider)
     {
         _dbContext = dbContext;
+        this.leagueProvider = leagueProvider;
     }
 
     public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -48,6 +52,7 @@ public sealed class InsertLeagueIdAttribute : ActionFilterAttribute
         }
 
         context.ActionArguments.Add("leagueId", leagueId);
+        leagueProvider.SetLeague(leagueId, leagueName);
 
         await base.OnActionExecutionAsync(context, next);
     }

--- a/src/iRLeagueApiCore.Server/Filters/SetTenantLeagueIdAttribute.cs
+++ b/src/iRLeagueApiCore.Server/Filters/SetTenantLeagueIdAttribute.cs
@@ -8,25 +8,15 @@ namespace iRLeagueApiCore.Server.Filters;
 /// <summary>
 /// Automatically insert the league id corresponding the league name in route parameters
 /// <para>
-/// Requires <b>{leagueName}</b> in Route and "<c><see cref="long"/> leagueId</c>" as parameter
+/// Requires <b>"{leagueName}"</b> in Route
 /// </para>
 /// </summary>
-/// <example>
-/// <code>
-/// [InsertLeague]
-/// [Route("{leagueName}/action")]
-/// public IActionResult Action([FromRoute] string leagueName, long leagueId, [FromServices] LeagueDbContext dbContext)
-/// {
-///     ...
-/// }
-/// </code>
-/// </example>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public sealed class InsertLeagueIdAttribute : ActionFilterAttribute
+public sealed class SetTenantLeagueIdAttribute : ActionFilterAttribute
 {
     private readonly LeagueDbContext _dbContext;
     private readonly RequestLeagueProvider leagueProvider;
-    public InsertLeagueIdAttribute(LeagueDbContext dbContext, RequestLeagueProvider leagueProvider)
+    public SetTenantLeagueIdAttribute(LeagueDbContext dbContext, RequestLeagueProvider leagueProvider)
     {
         _dbContext = dbContext;
         this.leagueProvider = leagueProvider;

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/ChampSeasonHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/ChampSeasonHandlerBase.cs
@@ -1,19 +1,23 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 using System.Linq.Expressions;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
 public class ChampSeasonHandlerBase<THandler, TRequest> : HandlerBase<THandler, TRequest>
 {
-    public ChampSeasonHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators) : 
+    protected readonly ILeagueProvider leagueProvider;
+
+    public ChampSeasonHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators, ILeagueProvider leagueProvider) :
         base(logger, dbContext, validators)
     {
+        this.leagueProvider = leagueProvider;
     }
 
-    protected virtual async Task<ChampSeasonEntity?> GetChampSeasonEntityAsync(long leagueId, long champSeasonId, CancellationToken cancellationToken)
+    protected virtual async Task<ChampSeasonEntity?> GetChampSeasonEntityAsync(long champSeasonId, CancellationToken cancellationToken)
     {
-        return await ChampSeasonsQuery(leagueId)
+        return await ChampSeasonsQuery()
             .Include(x => x.Championship)
             .Include(x => x.StandingConfiguration)
             .Include(x => x.ResultConfigurations)
@@ -21,17 +25,17 @@ public class ChampSeasonHandlerBase<THandler, TRequest> : HandlerBase<THandler, 
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    protected virtual async Task<ChampSeasonEntity> MapToChampSeasonEntityAsync(long leagueId, LeagueUser user, PutChampSeasonModel model, ChampSeasonEntity target, 
+    protected virtual async Task<ChampSeasonEntity> MapToChampSeasonEntityAsync(LeagueUser user, PutChampSeasonModel model, ChampSeasonEntity target, 
         CancellationToken cancellationToken)
     {
         target.Championship.Name = model.ChampionshipName;
         target.Championship.DisplayName = model.ChampionshipDisplayName;
-        target.StandingConfiguration = await MapToStandingConfigurationAsync(leagueId, user, model.StandingConfig, cancellationToken);
-        target.ResultConfigurations = await MapToResultConfigurationListAsync(leagueId, model.ResultConfigs.Select(x => x.ResultConfigId), target.ResultConfigurations, cancellationToken);
+        target.StandingConfiguration = await MapToStandingConfigurationAsync(user, model.StandingConfig, cancellationToken);
+        target.ResultConfigurations = await MapToResultConfigurationListAsync(model.ResultConfigs.Select(x => x.ResultConfigId), target.ResultConfigurations, cancellationToken);
         return await Task.FromResult(target);
     }
 
-    protected async Task<StandingConfigurationEntity?> MapToStandingConfigurationAsync(long leagueId, LeagueUser user, StandingConfigModel? model, CancellationToken cancellationToken)
+    protected async Task<StandingConfigurationEntity?> MapToStandingConfigurationAsync(LeagueUser user, StandingConfigModel? model, CancellationToken cancellationToken)
     {
         if (model is null)
         {
@@ -39,14 +43,13 @@ public class ChampSeasonHandlerBase<THandler, TRequest> : HandlerBase<THandler, 
         }
 
         var entity =  await dbContext.StandingConfigurations
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.StandingConfigId == model.StandingConfigId && model.StandingConfigId != 0)
             .FirstOrDefaultAsync(cancellationToken);
         if (entity is null)
         {
             entity = CreateVersionEntity(user, new StandingConfigurationEntity()
             {
-                LeagueId = leagueId,
+                LeagueId = leagueProvider.LeagueId,
             });
         }
         entity.Name = model.Name;
@@ -57,28 +60,26 @@ public class ChampSeasonHandlerBase<THandler, TRequest> : HandlerBase<THandler, 
         return entity;
     }
 
-    protected async Task<ICollection<ResultConfigurationEntity>> MapToResultConfigurationListAsync(long leagueId, IEnumerable<long> resultConfigId, 
+    protected async Task<ICollection<ResultConfigurationEntity>> MapToResultConfigurationListAsync(IEnumerable<long> resultConfigId, 
         ICollection<ResultConfigurationEntity> target, CancellationToken cancellationToken)
     {
         target = await dbContext.ResultConfigurations
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => resultConfigId.Contains(x.ResultConfigId))
             .ToListAsync(cancellationToken);
         return target;
     }
 
-    protected async Task<ChampSeasonModel?> MapToChampSeasonModel(long leagueId, long champSeasonId, CancellationToken cancellationToken)
+    protected async Task<ChampSeasonModel?> MapToChampSeasonModel(long champSeasonId, CancellationToken cancellationToken)
     {
-        return await ChampSeasonsQuery(leagueId)
+        return await ChampSeasonsQuery()
             .Where(x => x.ChampSeasonId == champSeasonId)
             .Select(MapToChampSeasonModelExpression)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    protected IQueryable<ChampSeasonEntity> ChampSeasonsQuery(long leagueId)
+    protected IQueryable<ChampSeasonEntity> ChampSeasonsQuery()
     {
         return dbContext.ChampSeasons
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.IsActive);
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/ChampSeasonHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/ChampSeasonHandlerBase.cs
@@ -6,13 +6,9 @@ using System.Linq.Expressions;
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
 public class ChampSeasonHandlerBase<THandler, TRequest> : HandlerBase<THandler, TRequest>
-{
-    protected readonly ILeagueProvider leagueProvider;
-
-    public ChampSeasonHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators, ILeagueProvider leagueProvider) :
+{    public ChampSeasonHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators) :
         base(logger, dbContext, validators)
     {
-        this.leagueProvider = leagueProvider;
     }
 
     protected virtual async Task<ChampSeasonEntity?> GetChampSeasonEntityAsync(long champSeasonId, CancellationToken cancellationToken)
@@ -49,7 +45,7 @@ public class ChampSeasonHandlerBase<THandler, TRequest> : HandlerBase<THandler, 
         {
             entity = CreateVersionEntity(user, new StandingConfigurationEntity()
             {
-                LeagueId = leagueProvider.LeagueId,
+                LeagueId = dbContext.LeagueProvider.LeagueId,
             });
         }
         entity.Name = model.Name;

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/ChampionshipHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/ChampionshipHandlerBase.cs
@@ -11,11 +11,10 @@ public class ChampionshipHandlerBase<THandler, TRequest> : HandlerBase<THandler,
     {
     }
 
-    protected virtual async Task<ChampionshipEntity?> GetChampionshipEntityAsync(long leagueId, long championshipId, CancellationToken cancellationToken)
+    protected virtual async Task<ChampionshipEntity?> GetChampionshipEntityAsync(long championshipId, CancellationToken cancellationToken)
     {
         return await dbContext.Championships
             .Include(x => x.ChampSeasons)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ChampionshipId == championshipId)
             .FirstOrDefaultAsync(cancellationToken);
     }
@@ -29,10 +28,9 @@ public class ChampionshipHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         return await Task.FromResult(target);
     }
 
-    protected virtual async Task<ChampionshipModel?> MapToChampionshipModelAsync(long leagueId, long championshipId, CancellationToken cancellationToken)
+    protected virtual async Task<ChampionshipModel?> MapToChampionshipModelAsync(long championshipId, CancellationToken cancellationToken)
     {
         return await dbContext.Championships
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ChampionshipId == championshipId)
             .Where(x => x.IsArchived == false)
             .Select(MapToChampionshipModelExpression)

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/DeleteChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/DeleteChampSeasonHandler.cs
@@ -1,19 +1,22 @@
-﻿namespace iRLeagueApiCore.Server.Handlers.Championships;
+﻿using iRLeagueDatabaseCore;
 
-public record DeleteChampSeasonRequest(long LeagueId, long ChampSeasonId) : IRequest;
+namespace iRLeagueApiCore.Server.Handlers.Championships;
+
+public record DeleteChampSeasonRequest(long ChampSeasonId) : IRequest;
 
 public sealed class DeleteChampSeasonHandler : ChampSeasonHandlerBase<DeleteChampSeasonHandler, DeleteChampSeasonRequest>,
     IRequestHandler<DeleteChampSeasonRequest, Unit>
 {
-    public DeleteChampSeasonHandler(ILogger<DeleteChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<DeleteChampSeasonRequest>> validators) :
-        base(logger, dbContext, validators)
+    public DeleteChampSeasonHandler(ILogger<DeleteChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<DeleteChampSeasonRequest>> validators, 
+        ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<Unit> Handle(DeleteChampSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteChampSeason = await GetChampSeasonEntityAsync(request.LeagueId, request.ChampSeasonId, cancellationToken)
+        var deleteChampSeason = await GetChampSeasonEntityAsync(request.ChampSeasonId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         deleteChampSeason.IsActive = false;
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/DeleteChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/DeleteChampSeasonHandler.cs
@@ -7,9 +7,8 @@ public record DeleteChampSeasonRequest(long ChampSeasonId) : IRequest;
 public sealed class DeleteChampSeasonHandler : ChampSeasonHandlerBase<DeleteChampSeasonHandler, DeleteChampSeasonRequest>,
     IRequestHandler<DeleteChampSeasonRequest, Unit>
 {
-    public DeleteChampSeasonHandler(ILogger<DeleteChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<DeleteChampSeasonRequest>> validators, 
-        ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+    public DeleteChampSeasonHandler(ILogger<DeleteChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<DeleteChampSeasonRequest>> validators) :
+        base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/DeleteChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/DeleteChampionshipHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record DeleteChampionshipRequest(long LeagueId, long ChampionshipId) : IRequest;
+public record DeleteChampionshipRequest(long ChampionshipId) : IRequest;
 
 public class DeleteChampionshipHandler : ChampionshipHandlerBase<DeleteChampionshipHandler, DeleteChampionshipRequest>,
     IRequestHandler<DeleteChampionshipRequest, Unit>
@@ -13,7 +13,7 @@ public class DeleteChampionshipHandler : ChampionshipHandlerBase<DeleteChampions
     public async Task<Unit> Handle(DeleteChampionshipRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteChampionship = await GetChampionshipEntityAsync(request.LeagueId, request.ChampionshipId, cancellationToken)
+        var deleteChampionship = await GetChampionshipEntityAsync(request.ChampionshipId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         // only archive championship instead of deleting
         deleteChampionship.IsArchived = true;

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonFromSeasonChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonFromSeasonChampionshipHandler.cs
@@ -9,8 +9,8 @@ public class GetChampSeasonFromSeasonChampionshipHandler : ChampSeasonHandlerBas
     IRequestHandler<GetChampSeasonFromSeasonChampionshipRequest, ChampSeasonModel>
 {
     public GetChampSeasonFromSeasonChampionshipHandler(ILogger<GetChampSeasonFromSeasonChampionshipHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetChampSeasonFromSeasonChampionshipRequest>> validators, ILeagueProvider leagueProvider) : 
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<GetChampSeasonFromSeasonChampionshipRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonFromSeasonChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonFromSeasonChampionshipHandler.cs
@@ -1,30 +1,30 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record GetChampSeasonFromSeasonChampionshipRequest(long LeagueId, long SeasonId, long ChampionshipId) : IRequest<ChampSeasonModel>;
+public record GetChampSeasonFromSeasonChampionshipRequest(long SeasonId, long ChampionshipId) : IRequest<ChampSeasonModel>;
 
 public class GetChampSeasonFromSeasonChampionshipHandler : ChampSeasonHandlerBase<GetChampSeasonFromSeasonChampionshipHandler, GetChampSeasonFromSeasonChampionshipRequest>,
     IRequestHandler<GetChampSeasonFromSeasonChampionshipRequest, ChampSeasonModel>
 {
     public GetChampSeasonFromSeasonChampionshipHandler(ILogger<GetChampSeasonFromSeasonChampionshipHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetChampSeasonFromSeasonChampionshipRequest>> validators) : 
-        base(logger, dbContext, validators)
+        IEnumerable<IValidator<GetChampSeasonFromSeasonChampionshipRequest>> validators, ILeagueProvider leagueProvider) : 
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<ChampSeasonModel> Handle(GetChampSeasonFromSeasonChampionshipRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getChampSeason = await GetChampSeasonFromSeasonChampionship(request.LeagueId, request.SeasonId, request.ChampionshipId, cancellationToken)
+        var getChampSeason = await GetChampSeasonFromSeasonChampionship(request.SeasonId, request.ChampionshipId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getChampSeason;
     }
 
-    private async Task<ChampSeasonModel?> GetChampSeasonFromSeasonChampionship(long leagueId, long seasonId, long championshipId, CancellationToken cancellationToken)
+    private async Task<ChampSeasonModel?> GetChampSeasonFromSeasonChampionship(long seasonId, long championshipId, CancellationToken cancellationToken)
     {
         return await dbContext.ChampSeasons
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SeasonId == seasonId)
             .Where(x => x.ChampionshipId == championshipId)
             .Select(MapToChampSeasonModelExpression)

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonHandler.cs
@@ -1,21 +1,23 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record GetChampSeasonRequest(long LeagueId, long ChampSeasonId) : IRequest<ChampSeasonModel>;
+public record GetChampSeasonRequest(long ChampSeasonId) : IRequest<ChampSeasonModel>;
 
 public sealed class GetChampSeasonHandler : ChampSeasonHandlerBase<GetChampSeasonHandler, GetChampSeasonRequest>,
     IRequestHandler<GetChampSeasonRequest, ChampSeasonModel>
 {
-    public GetChampSeasonHandler(ILogger<GetChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetChampSeasonRequest>> validators) :
-        base(logger, dbContext, validators)
+    public GetChampSeasonHandler(ILogger<GetChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetChampSeasonRequest>> validators, 
+        ILeagueProvider leagueProvider) 
+        : base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<ChampSeasonModel> Handle(GetChampSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getChampSeason = await MapToChampSeasonModel(request.LeagueId, request.ChampSeasonId, cancellationToken)
+        var getChampSeason = await MapToChampSeasonModel(request.ChampSeasonId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getChampSeason;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonHandler.cs
@@ -8,9 +8,8 @@ public record GetChampSeasonRequest(long ChampSeasonId) : IRequest<ChampSeasonMo
 public sealed class GetChampSeasonHandler : ChampSeasonHandlerBase<GetChampSeasonHandler, GetChampSeasonRequest>,
     IRequestHandler<GetChampSeasonRequest, ChampSeasonModel>
 {
-    public GetChampSeasonHandler(ILogger<GetChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetChampSeasonRequest>> validators, 
-        ILeagueProvider leagueProvider) 
-        : base(logger, dbContext, validators, leagueProvider)
+    public GetChampSeasonHandler(ILogger<GetChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetChampSeasonRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromChampionshipHandler.cs
@@ -9,8 +9,8 @@ public sealed class GetChampSeasonFromChampionshipHandler : ChampSeasonHandlerBa
     IRequestHandler<GetChampSeasonsFromChampionshipRequest, IEnumerable<ChampSeasonModel>>
 {
     public GetChampSeasonFromChampionshipHandler(ILogger<GetChampSeasonFromChampionshipHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetChampSeasonsFromChampionshipRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<GetChampSeasonsFromChampionshipRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromChampionshipHandler.cs
@@ -1,29 +1,30 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record GetChampSeasonsFromChampionshipRequest(long LeagueId, long ChampionshipId) : IRequest<IEnumerable<ChampSeasonModel>>;
+public record GetChampSeasonsFromChampionshipRequest(long ChampionshipId) : IRequest<IEnumerable<ChampSeasonModel>>;
 
 public sealed class GetChampSeasonFromChampionshipHandler : ChampSeasonHandlerBase<GetChampSeasonFromChampionshipHandler, GetChampSeasonsFromChampionshipRequest>,
     IRequestHandler<GetChampSeasonsFromChampionshipRequest, IEnumerable<ChampSeasonModel>>
 {
     public GetChampSeasonFromChampionshipHandler(ILogger<GetChampSeasonFromChampionshipHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetChampSeasonsFromChampionshipRequest>> validators) :
-        base(logger, dbContext, validators)
+        IEnumerable<IValidator<GetChampSeasonsFromChampionshipRequest>> validators, ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<IEnumerable<ChampSeasonModel>> Handle(GetChampSeasonsFromChampionshipRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getChampSeasons = await MapToChampSeasonModelsFromChampionshipAsync(request.LeagueId, request.ChampionshipId, cancellationToken)
+        var getChampSeasons = await MapToChampSeasonModelsFromChampionshipAsync(request.ChampionshipId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getChampSeasons;
     }
 
-    private async Task<IEnumerable<ChampSeasonModel>> MapToChampSeasonModelsFromChampionshipAsync(long leagueId, long championshipId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ChampSeasonModel>> MapToChampSeasonModelsFromChampionshipAsync(long championshipId, CancellationToken cancellationToken)
     {
-        return await ChampSeasonsQuery(leagueId)
+        return await ChampSeasonsQuery()
             .Where(x => x.ChampionshipId == championshipId)
             .OrderByDescending(x => x.Season.SeasonStart)
             .Select(MapToChampSeasonModelExpression)

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromSeasonHandler.cs
@@ -1,29 +1,30 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record GetChampSeasonsFromSeasonRequest(long LeagueId, long SeasonId) : IRequest<IEnumerable<ChampSeasonModel>>;
+public record GetChampSeasonsFromSeasonRequest(long SeasonId) : IRequest<IEnumerable<ChampSeasonModel>>;
 
 public sealed class GetChampSeasonFromSeasonHandler : ChampSeasonHandlerBase<GetChampSeasonFromSeasonHandler, GetChampSeasonsFromSeasonRequest>,
     IRequestHandler<GetChampSeasonsFromSeasonRequest, IEnumerable<ChampSeasonModel>>
 {
     public GetChampSeasonFromSeasonHandler(ILogger<GetChampSeasonFromSeasonHandler> logger, LeagueDbContext dbContext,
-        IEnumerable<IValidator<GetChampSeasonsFromSeasonRequest>> validators) :
-        base(logger, dbContext, validators)
+        IEnumerable<IValidator<GetChampSeasonsFromSeasonRequest>> validators, ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<IEnumerable<ChampSeasonModel>> Handle(GetChampSeasonsFromSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getChampSeasons = await MapToChampSeasonModelsFromSeasonAsync(request.LeagueId, request.SeasonId, cancellationToken)
+        var getChampSeasons = await MapToChampSeasonModelsFromSeasonAsync(request.SeasonId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getChampSeasons;
     }
 
-    private async Task<IEnumerable<ChampSeasonModel>> MapToChampSeasonModelsFromSeasonAsync(long leagueId, long seasonId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ChampSeasonModel>> MapToChampSeasonModelsFromSeasonAsync(long seasonId, CancellationToken cancellationToken)
     {
-        return await ChampSeasonsQuery(leagueId)
+        return await ChampSeasonsQuery()
             .Where(x => x.SeasonId == seasonId)
             .Select(MapToChampSeasonModelExpression)
             .ToListAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampSeasonsFromSeasonHandler.cs
@@ -8,9 +8,9 @@ public record GetChampSeasonsFromSeasonRequest(long SeasonId) : IRequest<IEnumer
 public sealed class GetChampSeasonFromSeasonHandler : ChampSeasonHandlerBase<GetChampSeasonFromSeasonHandler, GetChampSeasonsFromSeasonRequest>,
     IRequestHandler<GetChampSeasonsFromSeasonRequest, IEnumerable<ChampSeasonModel>>
 {
-    public GetChampSeasonFromSeasonHandler(ILogger<GetChampSeasonFromSeasonHandler> logger, LeagueDbContext dbContext,
-        IEnumerable<IValidator<GetChampSeasonsFromSeasonRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+    public GetChampSeasonFromSeasonHandler(ILogger<GetChampSeasonFromSeasonHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<GetChampSeasonsFromSeasonRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampionshipHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record GetChampionshipRequest(long LeagueId, long ChampionshipId) : IRequest<ChampionshipModel>;
+public record GetChampionshipRequest(long ChampionshipId) : IRequest<ChampionshipModel>;
 
 public class GetChampionshipHandler : ChampionshipHandlerBase<GetChampionshipHandler, GetChampionshipRequest>, 
     IRequestHandler<GetChampionshipRequest, ChampionshipModel>
@@ -15,7 +15,7 @@ public class GetChampionshipHandler : ChampionshipHandlerBase<GetChampionshipHan
     public async Task<ChampionshipModel> Handle(GetChampionshipRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getChampionship = await MapToChampionshipModelAsync(request.LeagueId, request.ChampionshipId, cancellationToken)
+        var getChampionship = await MapToChampionshipModelAsync(request.ChampionshipId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getChampionship;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampionshipsFromLeagueHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/GetChampionshipsFromLeagueHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record GetChampionshipsFromLeagueRequest(long LeagueId) : IRequest<IEnumerable<ChampionshipModel>>;
+public record GetChampionshipsFromLeagueRequest() : IRequest<IEnumerable<ChampionshipModel>>;
 
 public sealed class GetChampionshipsFromLeagueHandler : ChampionshipHandlerBase<GetChampionshipsFromLeagueHandler, GetChampionshipsFromLeagueRequest>, 
     IRequestHandler<GetChampionshipsFromLeagueRequest, IEnumerable<ChampionshipModel>>
@@ -16,14 +16,13 @@ public sealed class GetChampionshipsFromLeagueHandler : ChampionshipHandlerBase<
     public async Task<IEnumerable<ChampionshipModel>> Handle(GetChampionshipsFromLeagueRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getChampionships = await MapToChampionshipModelsFromLeagueAsync(request.LeagueId, cancellationToken);
+        var getChampionships = await MapToChampionshipModelsFromLeagueAsync(cancellationToken);
         return getChampionships;
     }
 
-    private async Task<IEnumerable<ChampionshipModel>> MapToChampionshipModelsFromLeagueAsync(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ChampionshipModel>> MapToChampionshipModelsFromLeagueAsync(CancellationToken cancellationToken)
     {
         return await dbContext.Championships
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.IsArchived == false)
             .Select(MapToChampionshipModelExpression)
             .ToListAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/PostChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/PostChampSeasonHandler.cs
@@ -81,7 +81,7 @@ public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSea
     {
         var target = CreateVersionEntity(user, new StandingConfigurationEntity()
         {
-            LeagueId = leagueProvider.LeagueId,
+            LeagueId = dbContext.LeagueProvider.LeagueId,
         });
         var source = await dbContext.StandingConfigurations
             .Where(x => x.StandingConfigId == prevStandingConfigId)

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/PostChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/PostChampSeasonHandler.cs
@@ -1,44 +1,44 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 using System.Threading;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record PostChampSeasonRequest(long LeagueId, long ChampionshipId, long SeasonId, LeagueUser User, PostChampSeasonModel Model) : IRequest<ChampSeasonModel>;
+public record PostChampSeasonRequest(long ChampionshipId, long SeasonId, LeagueUser User, PostChampSeasonModel Model) : IRequest<ChampSeasonModel>;
 
 public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSeasonHandler, PostChampSeasonRequest>, 
     IRequestHandler<PostChampSeasonRequest, ChampSeasonModel>
 {
-    public PostChampSeasonHandler(ILogger<PostChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostChampSeasonRequest>> validators) : 
-        base(logger, dbContext, validators)
+    public PostChampSeasonHandler(ILogger<PostChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostChampSeasonRequest>> validators, 
+        ILeagueProvider leagueProvider) : 
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<ChampSeasonModel> Handle(PostChampSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var postChampSeason = await GetChampSeasonEntityAsync(request.LeagueId, request.ChampionshipId, request.SeasonId, cancellationToken)
-            ?? await CreateChampSeasonEntityAsync(request.User, request.LeagueId, request.ChampionshipId, request.SeasonId, cancellationToken);
+        var postChampSeason = await GetChampSeasonEntityAsync(request.ChampionshipId, request.SeasonId, cancellationToken)
+            ?? await CreateChampSeasonEntityAsync(request.User, request.ChampionshipId, request.SeasonId, cancellationToken);
         postChampSeason.IsActive = true;
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getChampSeason = await MapToChampSeasonModel(request.LeagueId, postChampSeason.ChampSeasonId, cancellationToken)
+        var getChampSeason = await MapToChampSeasonModel(postChampSeason.ChampSeasonId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource not found");
         return getChampSeason;
     }
 
-    private async Task<ChampSeasonEntity?> GetChampSeasonEntityAsync(long leagueId, long championshipId, long seasonId, CancellationToken cancellationToken)
+    private async Task<ChampSeasonEntity?> GetChampSeasonEntityAsync(long championshipId, long seasonId, CancellationToken cancellationToken)
     {
         return await dbContext.ChampSeasons
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ChampionshipId == championshipId)
             .Where(x => x.SeasonId == seasonId)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    private async Task<ChampSeasonEntity> CreateChampSeasonEntityAsync(LeagueUser user, long leagueId, long championshipId, long seasonId, CancellationToken cancellationToken)
+    private async Task<ChampSeasonEntity> CreateChampSeasonEntityAsync(LeagueUser user, long championshipId, long seasonId, CancellationToken cancellationToken)
     {
         var championship = await dbContext.Championships
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ChampionshipId == championshipId)
             .Include(x => x.ChampSeasons)
                 .ThenInclude(x => x.ResultConfigurations)
@@ -51,7 +51,6 @@ public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSea
         var season = await dbContext.Seasons
             .Include(x => x.ChampSeasons)
                 .ThenInclude(x => x.ResultConfigurations)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SeasonId == seasonId)
             .FirstOrDefaultAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();
@@ -69,8 +68,8 @@ public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSea
             .FirstOrDefault();
 
         // find previous season settings and copy
-        champSeason.StandingConfiguration = await CreateOrCopyStandingConfigEntity(user, leagueId, prevChampSeason?.StandingConfigId, cancellationToken);
-        champSeason.ResultConfigurations = await CopyResultConfigurationEntities(user, leagueId, champSeason, prevChampSeason?.ResultConfigurations.Select(x => x.ResultConfigId), cancellationToken);
+        champSeason.StandingConfiguration = await CreateOrCopyStandingConfigEntity(user, prevChampSeason?.StandingConfigId, cancellationToken);
+        champSeason.ResultConfigurations = await CopyResultConfigurationEntities(user, champSeason, prevChampSeason?.ResultConfigurations.Select(x => x.ResultConfigId), cancellationToken);
         UpdateVersionEntity(user, champSeason);
 
         championship.ChampSeasons.Add(champSeason);
@@ -79,14 +78,13 @@ public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSea
         return champSeason;
     }
 
-    private async Task<StandingConfigurationEntity> CreateOrCopyStandingConfigEntity(LeagueUser user, long leagueId, long? prevStandingConfigId, CancellationToken cancellationToken)
+    private async Task<StandingConfigurationEntity> CreateOrCopyStandingConfigEntity(LeagueUser user, long? prevStandingConfigId, CancellationToken cancellationToken)
     {
         var target = CreateVersionEntity(user, new StandingConfigurationEntity()
         {
-            LeagueId = leagueId,
+            LeagueId = leagueProvider.LeagueId,
         });
         var source = await dbContext.StandingConfigurations
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.StandingConfigId == prevStandingConfigId)
             .FirstOrDefaultAsync(cancellationToken);
         if (source is not null)
@@ -188,7 +186,7 @@ public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSea
         return sourceConfig;
     }
 
-    private async Task<ICollection<ResultConfigurationEntity>> CopyResultConfigurationEntities(LeagueUser user, long leagueId, ChampSeasonEntity targetChampSeason, IEnumerable<long>? prevResultConfigIds,
+    private async Task<ICollection<ResultConfigurationEntity>> CopyResultConfigurationEntities(LeagueUser user, ChampSeasonEntity targetChampSeason, IEnumerable<long>? prevResultConfigIds,
         CancellationToken cancellationToken)
     {
         if (prevResultConfigIds is null)
@@ -197,7 +195,6 @@ public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSea
         }
 
         var resultConfigs = await dbContext.ResultConfigurations
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => prevResultConfigIds.Contains(x.ResultConfigId))
             .Include(x => x.League)
             .Include(x => x.ChampSeason)

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/PostChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/PostChampSeasonHandler.cs
@@ -10,9 +10,8 @@ public record PostChampSeasonRequest(long ChampionshipId, long SeasonId, LeagueU
 public sealed class PostChampSeasonHandler : ChampSeasonHandlerBase<PostChampSeasonHandler, PostChampSeasonRequest>, 
     IRequestHandler<PostChampSeasonRequest, ChampSeasonModel>
 {
-    public PostChampSeasonHandler(ILogger<PostChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostChampSeasonRequest>> validators, 
-        ILeagueProvider leagueProvider) : 
-        base(logger, dbContext, validators, leagueProvider)
+    public PostChampSeasonHandler(ILogger<PostChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostChampSeasonRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/PutChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/PutChampSeasonHandler.cs
@@ -9,9 +9,8 @@ public record PutChampSeasonRequest(long ChampSeasonId, LeagueUser User, PutCham
 public sealed class PutChampSeasonHandler : ChampSeasonHandlerBase<PutChampSeasonHandler, PutChampSeasonRequest>,
     IRequestHandler<PutChampSeasonRequest, ChampSeasonModel>
 {
-    public PutChampSeasonHandler(ILogger<PutChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PutChampSeasonRequest>> validators, 
-        ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+    public PutChampSeasonHandler(ILogger<PutChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PutChampSeasonRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Championships/PutChampionshipHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Championships/PutChampionshipHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Championships;
 
-public record PutChampionshipRequest(long LeagueId, long ChampionshipId, LeagueUser User, PutChampionshipModel Model) : IRequest<ChampionshipModel>;
+public record PutChampionshipRequest(long ChampionshipId, LeagueUser User, PutChampionshipModel Model) : IRequest<ChampionshipModel>;
 
 public sealed class PutChampionshipHandler : ChampionshipHandlerBase<PutChampionshipHandler, PutChampionshipRequest>, 
     IRequestHandler<PutChampionshipRequest, ChampionshipModel>
@@ -16,11 +16,11 @@ public sealed class PutChampionshipHandler : ChampionshipHandlerBase<PutChampion
     public async Task<ChampionshipModel> Handle(PutChampionshipRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putChampionship = await GetChampionshipEntityAsync(request.LeagueId, request.ChampionshipId, cancellationToken)
+        var putChampionship = await GetChampionshipEntityAsync(request.ChampionshipId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putChampionship = await MapToChampionshipEntityAsync(request.User, request.Model, putChampionship, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getChampionship = await MapToChampionshipModelAsync(request.LeagueId, request.ChampionshipId, cancellationToken)
+        var getChampionship = await MapToChampionshipModelAsync(request.ChampionshipId, cancellationToken)
             ?? throw new InvalidOperationException("Updated resource was not found");
         return getChampionship;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Events/DeleteEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Events/DeleteEventHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Events;
 
-public record DeleteEventRequest(long LeagueId, long EventId) : IRequest;
+public record DeleteEventRequest(long EventId) : IRequest;
 
 public sealed class DeleteEventHandler : EventHandlerBase<DeleteEventHandler, DeleteEventRequest>, IRequestHandler<DeleteEventRequest>
 {
@@ -12,7 +12,7 @@ public sealed class DeleteEventHandler : EventHandlerBase<DeleteEventHandler, De
     public async Task<Unit> Handle(DeleteEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteEvent = await GetEventEntityAsync(request.LeagueId, request.EventId, cancellationToken)
+        var deleteEvent = await GetEventEntityAsync(request.EventId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Events
             .Remove(deleteEvent);

--- a/src/iRLeagueApiCore.Server/Handlers/Events/EventHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Events/EventHandlerBase.cs
@@ -11,15 +11,14 @@ public class EventHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReque
     {
     }
 
-    protected virtual async Task<EventEntity?> GetEventEntityAsync(long leagueId, long eventId, CancellationToken cancellationToken)
+    protected virtual async Task<EventEntity?> GetEventEntityAsync(long eventId, CancellationToken cancellationToken)
     {
         return await dbContext.Events
             .Include(x => x.Sessions)
             .Include(x => x.Track)
             .Include(x => x.ResultConfigs)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.EventId == eventId)
-            .FirstOrDefaultAsync();
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     protected virtual async Task<EventEntity> MapToEventEntityAsync(LeagueUser user, PostEventModel postEvent, EventEntity target, CancellationToken cancellationToken)
@@ -86,10 +85,9 @@ public class EventHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReque
         return UpdateVersionEntity(user, target);
     }
 
-    protected virtual async Task<EventModel?> MapToEventModelAsync(long leagueId, long eventId, bool includeDetails = false, CancellationToken cancellationToken = default)
+    protected virtual async Task<EventModel?> MapToEventModelAsync(long eventId, bool includeDetails = false, CancellationToken cancellationToken = default)
     {
         var query = dbContext.Events
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.EventId == eventId)
             .Select(MapToEventModelExpression(includeDetails));
         var sql = query.ToQueryString();

--- a/src/iRLeagueApiCore.Server/Handlers/Events/GetEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Events/GetEventHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Events;
 
-public record GetEventRequest(long LeagueId, long EventId, bool IncludeDetails) : IRequest<EventModel>;
+public record GetEventRequest(long EventId, bool IncludeDetails) : IRequest<EventModel>;
 
 public sealed class GetEventHandler : EventHandlerBase<GetEventHandler, GetEventRequest>, IRequestHandler<GetEventRequest, EventModel>
 {
@@ -14,7 +14,7 @@ public sealed class GetEventHandler : EventHandlerBase<GetEventHandler, GetEvent
     public async Task<EventModel> Handle(GetEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getEvent = await MapToEventModelAsync(request.LeagueId, request.EventId, includeDetails: request.IncludeDetails, cancellationToken: cancellationToken)
+        var getEvent = await MapToEventModelAsync(request.EventId, includeDetails: request.IncludeDetails, cancellationToken: cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getEvent;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Events/GetEventsFromScheduleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Events/GetEventsFromScheduleHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Events;
 
-public record GetEventsFromScheduleRequest(long LeagueId, long ScheduleId, bool IncludeDetails = false) : IRequest<IEnumerable<EventModel>>;
+public record GetEventsFromScheduleRequest(long ScheduleId, bool IncludeDetails = false) : IRequest<IEnumerable<EventModel>>;
 
 public sealed class GetEventsFromScheduleHandler : EventHandlerBase<GetEventsFromScheduleHandler, GetEventsFromScheduleRequest>,
     IRequestHandler<GetEventsFromScheduleRequest, IEnumerable<EventModel>>
@@ -15,17 +15,16 @@ public sealed class GetEventsFromScheduleHandler : EventHandlerBase<GetEventsFro
     public async Task<IEnumerable<EventModel>> Handle(GetEventsFromScheduleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getEvents = await MapToGetEventsFromScheduleAsync(request.LeagueId, request.ScheduleId, request.IncludeDetails, cancellationToken);
+        var getEvents = await MapToGetEventsFromScheduleAsync(request.ScheduleId, request.IncludeDetails, cancellationToken);
         return getEvents;
     }
 
-    private async Task<IEnumerable<EventModel>> MapToGetEventsFromScheduleAsync(long leagueId, long scheduleId, bool includeDetails = false,
+    private async Task<IEnumerable<EventModel>> MapToGetEventsFromScheduleAsync(long scheduleId, bool includeDetails = false,
         CancellationToken cancellationToken = default)
     {
         return await dbContext.Events
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ScheduleId == scheduleId)
             .Select(MapToEventModelExpression(includeDetails))
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 }

--- a/src/iRLeagueApiCore.Server/Handlers/Events/GetEventsFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Events/GetEventsFromSeasonHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Events;
 
-public record GetEventsFromSeasonRequest(long LeagueId, long SeasonId, bool IncludeDetails) : IRequest<IEnumerable<EventModel>>;
+public record GetEventsFromSeasonRequest(long SeasonId, bool IncludeDetails) : IRequest<IEnumerable<EventModel>>;
 
 public sealed class GetEventsFromSeasonHandler : EventHandlerBase<GetEventsFromSeasonHandler, GetEventsFromSeasonRequest>,
     IRequestHandler<GetEventsFromSeasonRequest, IEnumerable<EventModel>>
@@ -15,15 +15,14 @@ public sealed class GetEventsFromSeasonHandler : EventHandlerBase<GetEventsFromS
     public async Task<IEnumerable<EventModel>> Handle(GetEventsFromSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getEvents = await MapToEventsFromSeasonAsync(request.LeagueId, request.SeasonId, request.IncludeDetails, cancellationToken);
+        var getEvents = await MapToEventsFromSeasonAsync(request.SeasonId, request.IncludeDetails, cancellationToken);
         return getEvents;
     }
 
-    private async Task<IEnumerable<EventModel>> MapToEventsFromSeasonAsync(long leagueId, long seasonId, bool includeDetails = false,
+    private async Task<IEnumerable<EventModel>> MapToEventsFromSeasonAsync(long seasonId, bool includeDetails = false,
         CancellationToken cancellationToken = default)
     {
         return await dbContext.Events
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.Schedule.SeasonId == seasonId)
             .Select(MapToEventModelExpression(includeDetails))
             .ToListAsync();

--- a/src/iRLeagueApiCore.Server/Handlers/Events/PutEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Events/PutEventHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Events;
 
-public record PutEventRequest(long LeagueId, long EventId, LeagueUser User, PutEventModel Event) : IRequest<EventModel>;
+public record PutEventRequest(long EventId, LeagueUser User, PutEventModel Event) : IRequest<EventModel>;
 
 public sealed class PutEventHandler : EventHandlerBase<PutEventHandler, PutEventRequest>, IRequestHandler<PutEventRequest, EventModel>
 {
@@ -15,11 +15,11 @@ public sealed class PutEventHandler : EventHandlerBase<PutEventHandler, PutEvent
     public async Task<EventModel> Handle(PutEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putEvent = await GetEventEntityAsync(request.LeagueId, request.EventId, cancellationToken)
+        var putEvent = await GetEventEntityAsync(request.EventId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putEvent = await MapToEventEntityAsync(request.User, request.Event, putEvent, cancellationToken);
         dbContext.SaveChanges();
-        var getEvent = await MapToEventModelAsync(request.LeagueId, putEvent.EventId, cancellationToken: cancellationToken)
+        var getEvent = await MapToEventModelAsync(putEvent.EventId, cancellationToken: cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getEvent;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
@@ -15,28 +15,34 @@ public abstract class HandlerBase<THandler, TRequest>
         this.validators = validators;
     }
 
+    protected virtual async Task<LeagueEntity?> GetLeagueEntityAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Leagues
+            .SingleOrDefaultAsync();
+    }
+
     protected virtual async Task<LeagueEntity?> GetLeagueEntityAsync(long leagueId, CancellationToken cancellationToken)
     {
         return await dbContext.Leagues
-            .SingleOrDefaultAsync(x => x.Id == leagueId);
+            .FirstOrDefaultAsync(x => x.Id == leagueId);
     }
 
     protected virtual async Task<ScheduleEntity?> GetScheduleEntityAsync(long? scheduleId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Schedules
-            .SingleOrDefaultAsync(x => x.ScheduleId == scheduleId, cancellationToken);
+            .FirstOrDefaultAsync(x => x.ScheduleId == scheduleId, cancellationToken);
     }
 
     protected virtual async Task<ScoringEntity?> GetScoringEntityAsync(long? scoringId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Scorings
-            .SingleOrDefaultAsync(x => x.ScoringId == scoringId, cancellationToken);
+            .FirstOrDefaultAsync(x => x.ScoringId == scoringId, cancellationToken);
     }
 
     protected virtual async Task<SeasonEntity?> GetSeasonEntityAsync(long? seasonId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Seasons
-            .SingleOrDefaultAsync(x => x.SeasonId == seasonId, cancellationToken);
+            .FirstOrDefaultAsync(x => x.SeasonId == seasonId, cancellationToken);
     }
 
     protected virtual async Task<TrackConfigEntity?> GetTrackConfigEntityAsync(long? trackConfigId, CancellationToken cancellationToken = default)

--- a/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
@@ -15,10 +15,16 @@ public abstract class HandlerBase<THandler, TRequest>
         this.validators = validators;
     }
 
-    protected virtual async Task<LeagueEntity?> GetLeagueEntityAsync(long leagueId, CancellationToken cancellationToken)
+    protected virtual async Task<LeagueEntity?> GetCurrentLeagueEntityAsync(CancellationToken cancellationToken = default)
     {
         return await dbContext.Leagues
-            .FirstOrDefaultAsync(x => x.Id == leagueId);
+            .FirstOrDefaultAsync(x => x.Id == dbContext.LeagueProvider.LeagueId, cancellationToken);
+    }
+
+    protected virtual async Task<LeagueEntity?> GetLeagueEntityAsync(long leagueId, CancellationToken cancellationToken = default)
+    {
+        return await dbContext.Leagues
+            .FirstOrDefaultAsync(x => x.Id == leagueId, cancellationToken);
     }
 
     protected virtual async Task<ScheduleEntity?> GetScheduleEntityAsync(long? scheduleId, CancellationToken cancellationToken = default)
@@ -51,10 +57,10 @@ public abstract class HandlerBase<THandler, TRequest>
             .FirstOrDefaultAsync(x => x.Id == memberId, cancellationToken);
     }
 
-    protected virtual async Task<VoteCategoryEntity?> GetVoteCategoryEntityAsync(long leagueId, long? voteCategoryId)
+    protected virtual async Task<VoteCategoryEntity?> GetVoteCategoryEntityAsync(long leagueId, long? voteCategoryId, CancellationToken cancellationToken = default)
     {
         return await dbContext.VoteCategories
-            .FirstOrDefaultAsync(x => x.CatId == voteCategoryId);
+            .FirstOrDefaultAsync(x => x.CatId == voteCategoryId, cancellationToken);
     }
 
     protected virtual async Task<ICollection<MemberEntity>> GetMemberListAsync(IEnumerable<long> memberIds, CancellationToken cancellationToken = default)

--- a/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
@@ -21,10 +21,9 @@ public abstract class HandlerBase<THandler, TRequest>
             .SingleOrDefaultAsync(x => x.Id == leagueId);
     }
 
-    protected virtual async Task<ScheduleEntity?> GetScheduleEntityAsync(long leagueId, long? scheduleId, CancellationToken cancellationToken = default)
+    protected virtual async Task<ScheduleEntity?> GetScheduleEntityAsync(long? scheduleId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Schedules
-            .Where(x => x.LeagueId == leagueId)
             .SingleOrDefaultAsync(x => x.ScheduleId == scheduleId, cancellationToken);
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
@@ -28,17 +28,15 @@ public abstract class HandlerBase<THandler, TRequest>
             .SingleOrDefaultAsync(x => x.ScheduleId == scheduleId, cancellationToken);
     }
 
-    protected virtual async Task<ScoringEntity?> GetScoringEntityAsync(long leagueId, long? scoringId, CancellationToken cancellationToken = default)
+    protected virtual async Task<ScoringEntity?> GetScoringEntityAsync(long? scoringId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Scorings
-            .Where(x => x.LeagueId == leagueId)
             .SingleOrDefaultAsync(x => x.ScoringId == scoringId, cancellationToken);
     }
 
-    protected virtual async Task<SeasonEntity?> GetSeasonEntityAsync(long leagueId, long? seasonId, CancellationToken cancellationToken = default)
+    protected virtual async Task<SeasonEntity?> GetSeasonEntityAsync(long? seasonId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Seasons
-            .Where(x => x.LeagueId == leagueId)
             .SingleOrDefaultAsync(x => x.SeasonId == seasonId, cancellationToken);
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/HandlerBase.cs
@@ -15,12 +15,6 @@ public abstract class HandlerBase<THandler, TRequest>
         this.validators = validators;
     }
 
-    protected virtual async Task<LeagueEntity?> GetLeagueEntityAsync(CancellationToken cancellationToken = default)
-    {
-        return await dbContext.Leagues
-            .SingleOrDefaultAsync();
-    }
-
     protected virtual async Task<LeagueEntity?> GetLeagueEntityAsync(long leagueId, CancellationToken cancellationToken)
     {
         return await dbContext.Leagues

--- a/src/iRLeagueApiCore.Server/Handlers/Members/GetMembersFromLeagueHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Members/GetMembersFromLeagueHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Members;
 
-public record GetMembersFromLeagueRequest(long LeagueId) : IRequest<IEnumerable<MemberModel>>;
+public record GetMembersFromLeagueRequest() : IRequest<IEnumerable<MemberModel>>;
 
 public sealed class GetMembersFromLeagueHandler : MembersHandlerBase<GetMembersFromLeagueHandler, GetMembersFromLeagueRequest>,
     IRequestHandler<GetMembersFromLeagueRequest, IEnumerable<MemberModel>>
@@ -14,14 +14,13 @@ public sealed class GetMembersFromLeagueHandler : MembersHandlerBase<GetMembersF
     public async Task<IEnumerable<MemberModel>> Handle(GetMembersFromLeagueRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getMembers = await MapToMemberModels(request.LeagueId, cancellationToken);
+        var getMembers = await MapToMemberModels(cancellationToken);
         return getMembers;
     }
 
-    private async Task<IEnumerable<MemberModel>> MapToMemberModels(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<MemberModel>> MapToMemberModels(CancellationToken cancellationToken)
     {
         return await dbContext.LeagueMembers
-            .Where(x => x.LeagueId == leagueId)
             .Select(MapToMemberModelExpression)
             .ToListAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Members/MembersHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Members/MembersHandlerBase.cs
@@ -10,10 +10,9 @@ public class MembersHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
     {
     }
 
-    protected async Task<IEnumerable<MemberModel>> MapToMemberListAsync(long leagueId, IEnumerable<long> memberIds, CancellationToken cancellationToken)
+    protected async Task<IEnumerable<MemberModel>> MapToMemberListAsync(IEnumerable<long> memberIds, CancellationToken cancellationToken)
     {
         return await dbContext.LeagueMembers
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => memberIds.Contains(x.MemberId))
             .Select(MapToMemberModelExpression)
             .ToListAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultConfigHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultConfigHandler.cs
@@ -8,8 +8,8 @@ public sealed class DeleteResultConfigHandler : ResultConfigHandlerBase<DeleteRe
     IRequestHandler<DeleteResultConfigRequest>
 {
     public DeleteResultConfigHandler(ILogger<DeleteResultConfigHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<DeleteResultConfigRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<DeleteResultConfigRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultConfigHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultConfigHandler.cs
@@ -1,19 +1,22 @@
-﻿namespace iRLeagueApiCore.Server.Handlers.Results;
+﻿using iRLeagueDatabaseCore;
 
-public record DeleteResultConfigRequest(long LeagueId, long ResultConfigId) : IRequest;
+namespace iRLeagueApiCore.Server.Handlers.Results;
+
+public record DeleteResultConfigRequest(long ResultConfigId) : IRequest;
 
 public sealed class DeleteResultConfigHandler : ResultConfigHandlerBase<DeleteResultConfigHandler, DeleteResultConfigRequest>,
     IRequestHandler<DeleteResultConfigRequest>
 {
-    public DeleteResultConfigHandler(ILogger<DeleteResultConfigHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<DeleteResultConfigRequest>> validators) :
-        base(logger, dbContext, validators)
+    public DeleteResultConfigHandler(ILogger<DeleteResultConfigHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<DeleteResultConfigRequest>> validators, ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<Unit> Handle(DeleteResultConfigRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteResultConfig = await GetResultConfigEntity(request.LeagueId, request.ResultConfigId, cancellationToken)
+        var deleteResultConfig = await GetResultConfigEntity(request.ResultConfigId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.ResultConfigurations.Remove(deleteResultConfig);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record DeleteResultRequest(long LeagueId, long EventId) : IRequest;
+public record DeleteResultRequest(long EventId) : IRequest;
 
 public sealed class DeleteResultHandler : ResultHandlerBase<DeleteResultHandler, DeleteResultRequest>,
     IRequestHandler<DeleteResultRequest, Unit>
@@ -13,8 +13,8 @@ public sealed class DeleteResultHandler : ResultHandlerBase<DeleteResultHandler,
     public async Task<Unit> Handle(DeleteResultRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteEventResults = await GetScoredEventResults(request.LeagueId, request.EventId, cancellationToken);
-        var deleteStandings = await GetEventStandings(request.LeagueId, request.EventId, cancellationToken);
+        var deleteEventResults = await GetScoredEventResults(request.EventId, cancellationToken);
+        var deleteStandings = await GetEventStandings(request.EventId, cancellationToken);
         foreach (var result in deleteEventResults)
         {
             dbContext.ScoredEventResults.Remove(result);
@@ -27,18 +27,16 @@ public sealed class DeleteResultHandler : ResultHandlerBase<DeleteResultHandler,
         return Unit.Value;
     }
 
-    private async Task<IEnumerable<ScoredEventResultEntity>> GetScoredEventResults(long leagueId, long eventId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ScoredEventResultEntity>> GetScoredEventResults(long eventId, CancellationToken cancellationToken)
     {
         return await dbContext.ScoredEventResults
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.EventId == eventId)
             .ToListAsync(cancellationToken);
     }
 
-    private async Task<IEnumerable<StandingEntity>> GetEventStandings(long leagueId, long eventId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<StandingEntity>> GetEventStandings(long eventId, CancellationToken cancellationToken)
     {
         return await dbContext.Standings
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.EventId == eventId)
             .ToListAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigHandler.cs
@@ -1,21 +1,23 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record GetResultConfigRequest(long LeagueId, long ResultConfigId) : IRequest<ResultConfigModel>;
+public record GetResultConfigRequest(long ResultConfigId) : IRequest<ResultConfigModel>;
 
 public sealed class GetResultConfigHandler : ResultConfigHandlerBase<GetResultConfigHandler, GetResultConfigRequest>,
     IRequestHandler<GetResultConfigRequest, ResultConfigModel>
 {
-    public GetResultConfigHandler(ILogger<GetResultConfigHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetResultConfigRequest>> validators) :
-        base(logger, dbContext, validators)
+    public GetResultConfigHandler(ILogger<GetResultConfigHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<GetResultConfigRequest>> validators, ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<ResultConfigModel> Handle(GetResultConfigRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getResultConfig = await MapToResultConfigModel(request.LeagueId, request.ResultConfigId, cancellationToken)
+        var getResultConfig = await MapToResultConfigModel(request.ResultConfigId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getResultConfig;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigHandler.cs
@@ -9,8 +9,8 @@ public sealed class GetResultConfigHandler : ResultConfigHandlerBase<GetResultCo
     IRequestHandler<GetResultConfigRequest, ResultConfigModel>
 {
     public GetResultConfigHandler(ILogger<GetResultConfigHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetResultConfigRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<GetResultConfigRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromLeagueHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromLeagueHandler.cs
@@ -8,9 +8,9 @@ public record GetResultConfigsFromLeagueRequest() : IRequest<IEnumerable<ResultC
 public sealed class GetResultConfigsFromLeagueHandler : ResultConfigHandlerBase<GetResultConfigsFromLeagueHandler, GetResultConfigsFromLeagueRequest>,
     IRequestHandler<GetResultConfigsFromLeagueRequest, IEnumerable<ResultConfigModel>>
 {
-    public GetResultConfigsFromLeagueHandler(ILogger<GetResultConfigsFromLeagueHandler> logger, LeagueDbContext dbContext,
-        IEnumerable<IValidator<GetResultConfigsFromLeagueRequest>> validators, ILeagueProvider leagueProvider) : 
-        base(logger, dbContext, validators, leagueProvider)
+    public GetResultConfigsFromLeagueHandler(ILogger<GetResultConfigsFromLeagueHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<GetResultConfigsFromLeagueRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromLeagueHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromLeagueHandler.cs
@@ -1,28 +1,29 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record GetResultConfigsFromLeagueRequest(long LeagueId) : IRequest<IEnumerable<ResultConfigModel>>;
+public record GetResultConfigsFromLeagueRequest() : IRequest<IEnumerable<ResultConfigModel>>;
 
 public sealed class GetResultConfigsFromLeagueHandler : ResultConfigHandlerBase<GetResultConfigsFromLeagueHandler, GetResultConfigsFromLeagueRequest>,
     IRequestHandler<GetResultConfigsFromLeagueRequest, IEnumerable<ResultConfigModel>>
 {
     public GetResultConfigsFromLeagueHandler(ILogger<GetResultConfigsFromLeagueHandler> logger, LeagueDbContext dbContext,
-        IEnumerable<IValidator<GetResultConfigsFromLeagueRequest>> validators) : base(logger, dbContext, validators)
+        IEnumerable<IValidator<GetResultConfigsFromLeagueRequest>> validators, ILeagueProvider leagueProvider) : 
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<IEnumerable<ResultConfigModel>> Handle(GetResultConfigsFromLeagueRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getResults = await MapToGetResultConfigsFromLeagueAsync(request.LeagueId, cancellationToken);
+        var getResults = await MapToGetResultConfigsFromLeagueAsync(cancellationToken);
         return getResults;
     }
 
-    private async Task<IEnumerable<ResultConfigModel>> MapToGetResultConfigsFromLeagueAsync(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ResultConfigModel>> MapToGetResultConfigsFromLeagueAsync(CancellationToken cancellationToken)
     {
         return await dbContext.ResultConfigurations
-            .Where(x => x.LeagueId == leagueId)
             .Select(MapToResultConfigModelExpression)
             .ToListAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromSeasonHandler.cs
@@ -1,28 +1,29 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record GetResultConfigsFromSeasonRequest(long LeagueId, long SeasonId) : IRequest<IEnumerable<ResultConfigModel>>;
+public record GetResultConfigsFromSeasonRequest(long SeasonId) : IRequest<IEnumerable<ResultConfigModel>>;
 
 public class GetResultConfigsFromSeasonHandler : ResultConfigHandlerBase<GetResultConfigsFromSeasonHandler, GetResultConfigsFromSeasonRequest>,
     IRequestHandler<GetResultConfigsFromSeasonRequest, IEnumerable<ResultConfigModel>>
 {
     public GetResultConfigsFromSeasonHandler(ILogger<GetResultConfigsFromSeasonHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetResultConfigsFromSeasonRequest>> validators) : base(logger, dbContext, validators)
+        IEnumerable<IValidator<GetResultConfigsFromSeasonRequest>> validators, ILeagueProvider leagueProvider) : 
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<IEnumerable<ResultConfigModel>> Handle(GetResultConfigsFromSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var configs = await GetResultConfigsFromSeasonAsync(request.LeagueId, request.SeasonId, cancellationToken);
+        var configs = await GetResultConfigsFromSeasonAsync(request.SeasonId, cancellationToken);
         return configs;
     }
 
-    private async Task<IEnumerable<ResultConfigModel>> GetResultConfigsFromSeasonAsync(long leagueId, long seasonId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ResultConfigModel>> GetResultConfigsFromSeasonAsync(long seasonId, CancellationToken cancellationToken)
     {
         return await dbContext.ChampSeasons
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SeasonId == seasonId)
             .Where(x => x.IsActive)
             .SelectMany(x => x.ResultConfigurations)

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultConfigsFromSeasonHandler.cs
@@ -9,8 +9,8 @@ public class GetResultConfigsFromSeasonHandler : ResultConfigHandlerBase<GetResu
     IRequestHandler<GetResultConfigsFromSeasonRequest, IEnumerable<ResultConfigModel>>
 {
     public GetResultConfigsFromSeasonHandler(ILogger<GetResultConfigsFromSeasonHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<GetResultConfigsFromSeasonRequest>> validators, ILeagueProvider leagueProvider) : 
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<GetResultConfigsFromSeasonRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record GetResultRequest(long LeagueId, long ResultId) : IRequest<EventResultModel>;
+public record GetResultRequest(long ResultId) : IRequest<EventResultModel>;
 
 public sealed class GetResultHandler : ResultHandlerBase<GetResultHandler, GetResultRequest>, IRequestHandler<GetResultRequest, EventResultModel>
 {
@@ -14,15 +14,14 @@ public sealed class GetResultHandler : ResultHandlerBase<GetResultHandler, GetRe
     public async Task<EventResultModel> Handle(GetResultRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getResult = await MapToEventResultModelAsync(request.LeagueId, request.ResultId, cancellationToken)
+        var getResult = await MapToEventResultModelAsync(request.ResultId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getResult;
     }
 
-    private async Task<EventResultModel?> MapToEventResultModelAsync(long leagueId, long resultId, CancellationToken cancellationToken)
+    private async Task<EventResultModel?> MapToEventResultModelAsync(long resultId, CancellationToken cancellationToken)
     {
         return await dbContext.ScoredEventResults
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ResultId == resultId)
             .Select(MapToEventResultModelExpression)
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultsFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultsFromSeasonHandler.cs
@@ -1,7 +1,7 @@
 ﻿using iRLeagueApiCore.Common.Models;
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record GetResultsFromSeasonRequest(long LeagueId, long SeasonId) : IRequest<IEnumerable<SeasonEventResultModel>>;
+public record GetResultsFromSeasonRequest(long SeasonId) : IRequest<IEnumerable<SeasonEventResultModel>>;
 
 public sealed class GetResultsFromSeasonHandler : ResultHandlerBase<GetResultsFromSeasonHandler, GetResultsFromSeasonRequest>,
     IRequestHandler<GetResultsFromSeasonRequest, IEnumerable<SeasonEventResultModel>>
@@ -14,7 +14,7 @@ public sealed class GetResultsFromSeasonHandler : ResultHandlerBase<GetResultsFr
     public async Task<IEnumerable<SeasonEventResultModel>> Handle(GetResultsFromSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getResults = await MapToGetResultModelsFromSeasonAsync(request.LeagueId, request.SeasonId, cancellationToken);
+        var getResults = await MapToGetResultModelsFromSeasonAsync(request.SeasonId, cancellationToken);
         if (getResults.Count() == 0)
         {
             throw new ResourceNotFoundException();
@@ -22,10 +22,9 @@ public sealed class GetResultsFromSeasonHandler : ResultHandlerBase<GetResultsFr
         return getResults;
     }
 
-    private async Task<IEnumerable<SeasonEventResultModel>> MapToGetResultModelsFromSeasonAsync(long leagueId, long seasonId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<SeasonEventResultModel>> MapToGetResultModelsFromSeasonAsync(long seasonId, CancellationToken cancellationToken)
     {
         var seasonResults = await dbContext.ScoredEventResults
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.Event.Schedule.SeasonId == seasonId)
             .OrderBy(x => x.Event.Date)
             .Select(MapToEventResultModelExpression)

--- a/src/iRLeagueApiCore.Server/Handlers/Results/GetResultsFromSessionHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/GetResultsFromSessionHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record GetResultsFromEventRequest(long LeagueId, long EventId) : IRequest<IEnumerable<EventResultModel>>;
+public record GetResultsFromEventRequest(long EventId) : IRequest<IEnumerable<EventResultModel>>;
 
 public sealed class GetResultsFromSessionHandler : ResultHandlerBase<GetResultsFromSessionHandler, GetResultsFromEventRequest>,
     IRequestHandler<GetResultsFromEventRequest, IEnumerable<EventResultModel>>
@@ -15,7 +15,7 @@ public sealed class GetResultsFromSessionHandler : ResultHandlerBase<GetResultsF
     public async Task<IEnumerable<EventResultModel>> Handle(GetResultsFromEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getResults = await MapToGetResultModelsFromSessionAsync(request.LeagueId, request.EventId, cancellationToken);
+        var getResults = await MapToGetResultModelsFromSessionAsync(request.EventId, cancellationToken);
         if (getResults.Count() == 0)
         {
             throw new ResourceNotFoundException();
@@ -23,10 +23,9 @@ public sealed class GetResultsFromSessionHandler : ResultHandlerBase<GetResultsF
         return getResults;
     }
 
-    private async Task<IEnumerable<EventResultModel>> MapToGetResultModelsFromSessionAsync(long leagueId, long eventId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<EventResultModel>> MapToGetResultModelsFromSessionAsync( long eventId, CancellationToken cancellationToken)
     {
         return await dbContext.ScoredEventResults
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.EventId == eventId)
             .Select(MapToEventResultModelExpression)
             .ToListAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Results/PostResultConfigToChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/PostResultConfigToChampSeasonHandler.cs
@@ -10,8 +10,8 @@ public sealed class PostResultConfigToChampSeasonHandler : ResultConfigHandlerBa
     IRequestHandler<PostResultConfigToChampSeasonRequest, ResultConfigModel>
 {
     public PostResultConfigToChampSeasonHandler(ILogger<PostResultConfigToChampSeasonHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<PostResultConfigToChampSeasonRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<PostResultConfigToChampSeasonRequest>> validators) :
+        base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Results/PostResultConfigToChampSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/PostResultConfigToChampSeasonHandler.cs
@@ -1,33 +1,34 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record PostResultConfigToChampSeasonRequest(long LeagueId, long ChampSeasonId, LeagueUser User, PostResultConfigModel Model) : IRequest<ResultConfigModel>;
+public record PostResultConfigToChampSeasonRequest(long ChampSeasonId, LeagueUser User, PostResultConfigModel Model) : IRequest<ResultConfigModel>;
 
 public sealed class PostResultConfigToChampSeasonHandler : ResultConfigHandlerBase<PostResultConfigToChampSeasonHandler, PostResultConfigToChampSeasonRequest>,
     IRequestHandler<PostResultConfigToChampSeasonRequest, ResultConfigModel>
 {
-    public PostResultConfigToChampSeasonHandler(ILogger<PostResultConfigToChampSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostResultConfigToChampSeasonRequest>> validators) :
-        base(logger, dbContext, validators)
+    public PostResultConfigToChampSeasonHandler(ILogger<PostResultConfigToChampSeasonHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<PostResultConfigToChampSeasonRequest>> validators, ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<ResultConfigModel> Handle(PostResultConfigToChampSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var postResultConfig = await CreateResultConfigEntity(request.LeagueId, request.ChampSeasonId, request.User, cancellationToken);
-        postResultConfig = await MapToResultConfigEntityAsync(request.LeagueId, request.User, request.Model, postResultConfig, cancellationToken);
+        var postResultConfig = await CreateResultConfigEntity(request.ChampSeasonId, request.User, cancellationToken);
+        postResultConfig = await MapToResultConfigEntityAsync(request.User, request.Model, postResultConfig, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getResultConfig = await MapToResultConfigModel(postResultConfig.LeagueId, postResultConfig.ResultConfigId, cancellationToken)
+        var getResultConfig = await MapToResultConfigModel(postResultConfig.ResultConfigId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getResultConfig;
     }
 
-    private async Task<ResultConfigurationEntity> CreateResultConfigEntity(long leagueId, long champSeasonId, LeagueUser user, CancellationToken cancellationToken)
+    private async Task<ResultConfigurationEntity> CreateResultConfigEntity(long champSeasonId, LeagueUser user, CancellationToken cancellationToken)
     {
         var champSeason = await dbContext.ChampSeasons
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ChampSeasonId == champSeasonId)
             .FirstOrDefaultAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();

--- a/src/iRLeagueApiCore.Server/Handlers/Results/PutResultConfigHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/PutResultConfigHandler.cs
@@ -1,26 +1,28 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record PutResultConfigRequest(long LeagueId, long ResultConfigId, LeagueUser User, PutResultConfigModel Model) : IRequest<ResultConfigModel>;
+public record PutResultConfigRequest(long ResultConfigId, LeagueUser User, PutResultConfigModel Model) : IRequest<ResultConfigModel>;
 
 public sealed class PutResultConfigHandler : ResultConfigHandlerBase<PutResultConfigHandler, PutResultConfigRequest>,
     IRequestHandler<PutResultConfigRequest, ResultConfigModel>
 {
-    public PutResultConfigHandler(ILogger<PutResultConfigHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PutResultConfigRequest>> validators) :
-        base(logger, dbContext, validators)
+    public PutResultConfigHandler(ILogger<PutResultConfigHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<PutResultConfigRequest>> validators, ILeagueProvider leagueProvider) :
+        base(logger, dbContext, validators, leagueProvider)
     {
     }
 
     public async Task<ResultConfigModel> Handle(PutResultConfigRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putResultConfig = await GetResultConfigEntity(request.LeagueId, request.ResultConfigId, cancellationToken)
+        var putResultConfig = await GetResultConfigEntity(request.ResultConfigId, cancellationToken)
             ?? throw new ResourceNotFoundException();
-        putResultConfig = await MapToResultConfigEntityAsync(request.LeagueId, request.User, request.Model, putResultConfig, cancellationToken);
+        putResultConfig = await MapToResultConfigEntityAsync(request.User, request.Model, putResultConfig, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getResultConfig = await MapToResultConfigModel(putResultConfig.LeagueId, putResultConfig.ResultConfigId, cancellationToken)
+        var getResultConfig = await MapToResultConfigModel(putResultConfig.ResultConfigId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getResultConfig;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Results/PutResultConfigHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/PutResultConfigHandler.cs
@@ -10,8 +10,8 @@ public sealed class PutResultConfigHandler : ResultConfigHandlerBase<PutResultCo
     IRequestHandler<PutResultConfigRequest, ResultConfigModel>
 {
     public PutResultConfigHandler(ILogger<PutResultConfigHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<PutResultConfigRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators, leagueProvider)
+        IEnumerable<IValidator<PutResultConfigRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
     }
 

--- a/src/iRLeagueApiCore.Server/Handlers/Results/ResultConfigHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/ResultConfigHandlerBase.cs
@@ -1,17 +1,21 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 using System.Linq.Expressions;
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
 public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler, TRequest>
 {
-    public ResultConfigHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators) :
+    private readonly ILeagueProvider leagueProvider;
+
+    public ResultConfigHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators, ILeagueProvider leagueProvider) :
         base(logger, dbContext, validators)
     {
+        this.leagueProvider = leagueProvider;
     }
 
-    protected virtual async Task<ResultConfigurationEntity?> GetResultConfigEntity(long leagueId, long resultConfigId, CancellationToken cancellationToken)
+    protected virtual async Task<ResultConfigurationEntity?> GetResultConfigEntity(long resultConfigId, CancellationToken cancellationToken)
     {
         return await dbContext.ResultConfigurations
             .Include(x => x.Scorings)
@@ -21,12 +25,11 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
                 .ThenInclude(x => x.Conditions)
             .Include(x => x.PointFilters)
                 .ThenInclude(x => x.Conditions)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ResultConfigId == resultConfigId)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    protected virtual async Task<ResultConfigurationEntity> MapToResultConfigEntityAsync(long leagueId, LeagueUser user, PostResultConfigModel postResultConfig,
+    protected virtual async Task<ResultConfigurationEntity> MapToResultConfigEntityAsync(LeagueUser user, PostResultConfigModel postResultConfig,
         ResultConfigurationEntity resultConfigEntity, CancellationToken cancellationToken)
     {
         resultConfigEntity.DisplayName = postResultConfig.DisplayName;
@@ -37,16 +40,16 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         resultConfigEntity.Name = postResultConfig.Name;
         resultConfigEntity.ResultKind = postResultConfig.ResultKind;
         resultConfigEntity.ResultsPerTeam = postResultConfig.ResultsPerTeam;
-        resultConfigEntity.Scorings = await MapToScoringList(leagueId, user, postResultConfig.Scorings, resultConfigEntity.Scorings, cancellationToken);
-        resultConfigEntity.PointFilters = await MapToFilterOptionListAsync(leagueId, user, postResultConfig.FiltersForPoints,
+        resultConfigEntity.Scorings = await MapToScoringList(user, postResultConfig.Scorings, resultConfigEntity.Scorings, cancellationToken);
+        resultConfigEntity.PointFilters = await MapToFilterOptionListAsync(user, postResultConfig.FiltersForPoints,
             resultConfigEntity.PointFilters, cancellationToken);
-        resultConfigEntity.ResultFilters = await MapToFilterOptionListAsync(leagueId, user, postResultConfig.FiltersForResult,
+        resultConfigEntity.ResultFilters = await MapToFilterOptionListAsync(user, postResultConfig.FiltersForResult,
             resultConfigEntity.ResultFilters, cancellationToken);
         UpdateVersionEntity(user, resultConfigEntity);
         return await Task.FromResult(resultConfigEntity);
     }
 
-    private async Task<ICollection<StandingConfigurationEntity>> MapToStandingConfigListAsync(long leagueId, LeagueUser user, StandingConfigModel? standingConfigModel,
+    private async Task<ICollection<StandingConfigurationEntity>> MapToStandingConfigListAsync(LeagueUser user, StandingConfigModel? standingConfigModel,
         ICollection<StandingConfigurationEntity> standingConfigurationEntities, CancellationToken cancellationToken)
     {
         if (standingConfigModel is null)
@@ -58,7 +61,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         if (standingConfigEntity is null)
         {
             standingConfigEntity = CreateVersionEntity(user, new StandingConfigurationEntity());
-            standingConfigEntity.LeagueId = leagueId;
+            standingConfigEntity.LeagueId = leagueProvider.LeagueId;
             standingConfigurationEntities.Clear();
             standingConfigurationEntities.Add(standingConfigEntity);
         }
@@ -70,7 +73,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         return await Task.FromResult(standingConfigurationEntities);
     }
 
-    private async Task<ICollection<FilterOptionEntity>> MapToFilterOptionListAsync(long leagueId, LeagueUser user, IEnumerable<ResultFilterModel> filterModels,
+    private async Task<ICollection<FilterOptionEntity>> MapToFilterOptionListAsync(LeagueUser user, IEnumerable<ResultFilterModel> filterModels,
         ICollection<FilterOptionEntity> filterEntities, CancellationToken cancellationToken)
     {
         foreach (var filterModel in filterModels)
@@ -81,7 +84,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
             {
                 filterOptionEntity = CreateVersionEntity(user, new FilterOptionEntity());
                 filterEntities.Add(filterOptionEntity);
-                filterOptionEntity.LeagueId = leagueId;
+                filterOptionEntity.LeagueId = leagueProvider.LeagueId;
             }
             await MapToFilterOptionEntityAsync(user, filterModel, filterOptionEntity, cancellationToken);
         }
@@ -112,7 +115,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         return Task.FromResult(filterOptionEntity);
     }
 
-    private async Task<ICollection<ScoringEntity>> MapToScoringList(long leagueId, LeagueUser user, ICollection<ScoringModel> scoringModels,
+    private async Task<ICollection<ScoringEntity>> MapToScoringList(LeagueUser user, ICollection<ScoringModel> scoringModels,
         ICollection<ScoringEntity> scoringEntities, CancellationToken cancellationToken)
     {
         // Map votes
@@ -124,9 +127,9 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
             {
                 scoringEntity = CreateVersionEntity(user, new ScoringEntity());
                 scoringEntities.Add(scoringEntity);
-                scoringEntity.LeagueId = leagueId;
+                scoringEntity.LeagueId = leagueProvider.LeagueId;
             }
-            await MapToScoringEntityAsync(leagueId, user, scoringModel, scoringEntity, cancellationToken);
+            await MapToScoringEntityAsync(user, scoringModel, scoringEntity, cancellationToken);
         }
         // Delete votes that are no longer in source collection
         var deleteScorings = scoringEntities
@@ -138,7 +141,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         return scoringEntities;
     }
 
-    private async Task<ScoringEntity> MapToScoringEntityAsync(long leagueId, LeagueUser user, ScoringModel scoringModel, ScoringEntity scoringEntity,
+    private async Task<ScoringEntity> MapToScoringEntityAsync(LeagueUser user, ScoringModel scoringModel, ScoringEntity scoringEntity,
         CancellationToken cancellationToken)
     {
         scoringEntity.Index = scoringModel.Index;
@@ -149,7 +152,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         scoringEntity.UseResultSetTeam = scoringModel.UseResultSetTeam;
         scoringEntity.UpdateTeamOnRecalculation = scoringModel.UpdateTeamOnRecalculation;
         scoringEntity.PointsRule = scoringModel.PointRule is not null ? await MapToPointRuleEntityAsync(user, scoringModel.PointRule,
-            scoringEntity.PointsRule ?? CreateVersionEntity(user, new PointRuleEntity() { LeagueId = leagueId}), cancellationToken) : null;
+            scoringEntity.PointsRule ?? CreateVersionEntity(user, new PointRuleEntity() { LeagueId = leagueProvider.LeagueId }), cancellationToken) : null;
         scoringEntity.UseExternalSourcePoints = scoringModel.UseSourcePoints;
         UpdateVersionEntity(user, scoringEntity);
         return await Task.FromResult(scoringEntity);
@@ -169,15 +172,14 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         return await Task.FromResult(pointRuleEntity);
     }
 
-    protected virtual async Task<ResultConfigurationEntity> MapToResultConfigEntityAsync(long leagueId, LeagueUser user, PutResultConfigModel putResultConfig, ResultConfigurationEntity resultConfigEntity, CancellationToken cancellationToken)
+    protected virtual async Task<ResultConfigurationEntity> MapToResultConfigEntityAsync(LeagueUser user, PutResultConfigModel putResultConfig, ResultConfigurationEntity resultConfigEntity, CancellationToken cancellationToken)
     {
-        return await MapToResultConfigEntityAsync(leagueId, user, (PostResultConfigModel)putResultConfig, resultConfigEntity, cancellationToken);
+        return await MapToResultConfigEntityAsync(user, (PostResultConfigModel)putResultConfig, resultConfigEntity, cancellationToken);
     }
 
-    protected virtual async Task<ResultConfigModel?> MapToResultConfigModel(long leagueId, long resultConfigId, CancellationToken cancellationToken)
+    protected virtual async Task<ResultConfigModel?> MapToResultConfigModel(long resultConfigId, CancellationToken cancellationToken)
     {
         return await dbContext.ResultConfigurations
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ResultConfigId == resultConfigId)
             .Select(MapToResultConfigModelExpression)
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Results/ResultConfigHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/ResultConfigHandlerBase.cs
@@ -7,12 +7,9 @@ namespace iRLeagueApiCore.Server.Handlers.Results;
 
 public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler, TRequest>
 {
-    private readonly ILeagueProvider leagueProvider;
-
-    public ResultConfigHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators, ILeagueProvider leagueProvider) :
+    public ResultConfigHandlerBase(ILogger<THandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<TRequest>> validators) :
         base(logger, dbContext, validators)
     {
-        this.leagueProvider = leagueProvider;
     }
 
     protected virtual async Task<ResultConfigurationEntity?> GetResultConfigEntity(long resultConfigId, CancellationToken cancellationToken)
@@ -61,7 +58,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         if (standingConfigEntity is null)
         {
             standingConfigEntity = CreateVersionEntity(user, new StandingConfigurationEntity());
-            standingConfigEntity.LeagueId = leagueProvider.LeagueId;
+            standingConfigEntity.LeagueId = dbContext.LeagueProvider.LeagueId;
             standingConfigurationEntities.Clear();
             standingConfigurationEntities.Add(standingConfigEntity);
         }
@@ -84,7 +81,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
             {
                 filterOptionEntity = CreateVersionEntity(user, new FilterOptionEntity());
                 filterEntities.Add(filterOptionEntity);
-                filterOptionEntity.LeagueId = leagueProvider.LeagueId;
+                filterOptionEntity.LeagueId = dbContext.LeagueProvider.LeagueId;
             }
             await MapToFilterOptionEntityAsync(user, filterModel, filterOptionEntity, cancellationToken);
         }
@@ -127,7 +124,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
             {
                 scoringEntity = CreateVersionEntity(user, new ScoringEntity());
                 scoringEntities.Add(scoringEntity);
-                scoringEntity.LeagueId = leagueProvider.LeagueId;
+                scoringEntity.LeagueId = dbContext.LeagueProvider.LeagueId;
             }
             await MapToScoringEntityAsync(user, scoringModel, scoringEntity, cancellationToken);
         }
@@ -152,7 +149,7 @@ public class ResultConfigHandlerBase<THandler, TRequest> : HandlerBase<THandler,
         scoringEntity.UseResultSetTeam = scoringModel.UseResultSetTeam;
         scoringEntity.UpdateTeamOnRecalculation = scoringModel.UpdateTeamOnRecalculation;
         scoringEntity.PointsRule = scoringModel.PointRule is not null ? await MapToPointRuleEntityAsync(user, scoringModel.PointRule,
-            scoringEntity.PointsRule ?? CreateVersionEntity(user, new PointRuleEntity() { LeagueId = leagueProvider.LeagueId }), cancellationToken) : null;
+            scoringEntity.PointsRule ?? CreateVersionEntity(user, new PointRuleEntity() { LeagueId = dbContext.LeagueProvider.LeagueId }), cancellationToken) : null;
         scoringEntity.UseExternalSourcePoints = scoringModel.UseSourcePoints;
         UpdateVersionEntity(user, scoringEntity);
         return await Task.FromResult(scoringEntity);

--- a/src/iRLeagueApiCore.Server/Handlers/Results/TriggerResultCalculationHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/TriggerResultCalculationHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Results;
 
-public record TriggerResultCalculationCommand(long LeagueId, long EventId) : IRequest;
+public record TriggerResultCalculationCommand(long EventId) : IRequest;
 
 public sealed class TriggerResultCalculationHandler : ResultHandlerBase<TriggerResultCalculationHandler, TriggerResultCalculationCommand>,
     IRequestHandler<TriggerResultCalculationCommand, Unit>
@@ -19,7 +19,6 @@ public sealed class TriggerResultCalculationHandler : ResultHandlerBase<TriggerR
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
         var @event = await dbContext.Events
-            .Where(x => x.LeagueId == request.LeagueId)
             .Where(x => x.EventId == request.EventId)
             .FirstOrDefaultAsync(cancellationToken);
         if (@event is null)

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/CommentHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/CommentHandlerBase.cs
@@ -12,11 +12,10 @@ public class CommentHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
     {
     }
 
-    protected virtual async Task<ReviewCommentEntity?> GetCommentEntityAsync(long leagueId, long commentId, CancellationToken cancellationToken)
+    protected virtual async Task<ReviewCommentEntity?> GetCommentEntityAsync(long commentId, CancellationToken cancellationToken)
     {
         return await dbContext.ReviewComments
             .Include(x => x.ReviewCommentVotes)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.CommentId == commentId)
             .FirstOrDefaultAsync();
     }
@@ -69,10 +68,9 @@ public class CommentHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
         return voteEntities;
     }
 
-    protected virtual async Task<ReviewCommentModel?> MapToReviewCommentModelAsync(long leagueId, long commentId, CancellationToken cancellationToken)
+    protected virtual async Task<ReviewCommentModel?> MapToReviewCommentModelAsync(long commentId, CancellationToken cancellationToken)
     {
         return await dbContext.ReviewComments
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.CommentId == commentId)
             .Select(MapToReviewCommentModelExpression)
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteProtestHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteProtestHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record DeleteProtestRequest(long LeagueId, long ProtestId) : IRequest;
+public record DeleteProtestRequest(long ProtestId) : IRequest;
 
 public class DeleteProtestHandler : ProtestsHandlerBase<DeleteProtestHandler, DeleteProtestRequest>, 
     IRequestHandler<DeleteProtestRequest, Unit>
@@ -13,7 +13,7 @@ public class DeleteProtestHandler : ProtestsHandlerBase<DeleteProtestHandler, De
     public async Task<Unit> Handle(DeleteProtestRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteProtest = await GetProtestEntityAsync(request.LeagueId, request.ProtestId, cancellationToken)
+        var deleteProtest = await GetProtestEntityAsync(request.ProtestId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Protests.Remove(deleteProtest);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteReviewCommentHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteReviewCommentHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record DeleteReviewCommentRequest(long LeagueId, long CommentId) : IRequest;
+public record DeleteReviewCommentRequest(long CommentId) : IRequest;
 
 public sealed class DeleteReviewCommentHandler : CommentHandlerBase<DeleteReviewCommentHandler, DeleteReviewCommentRequest>,
     IRequestHandler<DeleteReviewCommentRequest>
@@ -13,7 +13,7 @@ public sealed class DeleteReviewCommentHandler : CommentHandlerBase<DeleteReview
     public async Task<Unit> Handle(DeleteReviewCommentRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteComment = await GetCommentEntityAsync(request.LeagueId, request.CommentId, cancellationToken)
+        var deleteComment = await GetCommentEntityAsync(request.CommentId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Remove(deleteComment);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteReviewHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteReviewHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record DeleteReviewRequest(long LeagueId, long ReviewId) : IRequest;
+public record DeleteReviewRequest(long ReviewId) : IRequest;
 
 public sealed class DeleteReviewHandler : ReviewsHandlerBase<DeleteReviewHandler, DeleteReviewRequest>,
     IRequestHandler<DeleteReviewRequest>
@@ -13,7 +13,7 @@ public sealed class DeleteReviewHandler : ReviewsHandlerBase<DeleteReviewHandler
     public async Task<Unit> Handle(DeleteReviewRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteReview = await GetReviewEntity(request.LeagueId, request.ReviewId, cancellationToken)
+        var deleteReview = await GetReviewEntity(request.ReviewId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Remove(deleteReview);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteVoteCategoryHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/DeleteVoteCategoryHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record DeleteVoteCategoryRequest(long LeagueId, long CatId) : IRequest;
+public record DeleteVoteCategoryRequest(long CatId) : IRequest;
 
 public class DeleteVoteCategoryHandler : VoteCategoriesHandlerBase<DeleteVoteCategoryHandler, DeleteVoteCategoryRequest>, 
     IRequestHandler<DeleteVoteCategoryRequest, Unit>
@@ -13,7 +13,7 @@ public class DeleteVoteCategoryHandler : VoteCategoriesHandlerBase<DeleteVoteCat
     public async Task<Unit> Handle(DeleteVoteCategoryRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteVoteCategory = await GetVoteCategoryEntityAsync(request.LeagueId, request.CatId, cancellationToken)
+        var deleteVoteCategory = await GetVoteCategoryEntityAsync(request.CatId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Remove(deleteVoteCategory);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetLeagueVoteCategoriesHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetLeagueVoteCategoriesHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record GetLeagueVoteCategoriesRequest(long LeagueId) : IRequest<IEnumerable<VoteCategoryModel>>;
+public record GetLeagueVoteCategoriesRequest() : IRequest<IEnumerable<VoteCategoryModel>>;
 
 public sealed class GetLeagueVoteCategoriesHandler : VoteCategoriesHandlerBase<GetLeagueVoteCategoriesHandler, GetLeagueVoteCategoriesRequest>,
     IRequestHandler<GetLeagueVoteCategoriesRequest, IEnumerable<VoteCategoryModel>>
@@ -16,14 +16,13 @@ public sealed class GetLeagueVoteCategoriesHandler : VoteCategoriesHandlerBase<G
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
 
-        var getVoteCategories = await MapToLeagueVoteCategoryModels(request.LeagueId, cancellationToken);
+        var getVoteCategories = await MapToLeagueVoteCategoryModels(cancellationToken);
         return getVoteCategories;
     }
 
-    private async Task<IEnumerable<VoteCategoryModel>> MapToLeagueVoteCategoryModels(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<VoteCategoryModel>> MapToLeagueVoteCategoryModels(CancellationToken cancellationToken)
     {
         return await dbContext.VoteCategories
-            .Where(x => x.LeagueId == leagueId)
             .OrderBy(x => x.Index)
             .Select(MapToVoteCategoryModelExpression)
             .ToListAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetProtestsFromEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetProtestsFromEventHandler.cs
@@ -10,18 +10,15 @@ public record GetProtestsFromEventRequest(LeagueUser User, long EventId) : IRequ
 public class GetProtestsFromEventHandler : ProtestsHandlerBase<GetProtestsFromEventHandler, GetProtestsFromEventRequest>, IRequestHandler<GetProtestsFromEventRequest, 
     IEnumerable<ProtestModel>>
 {
-    private readonly ILeagueProvider leagueProvider;
-
-    public GetProtestsFromEventHandler(ILogger<GetProtestsFromEventHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetProtestsFromEventRequest>> validators, ILeagueProvider leagueProvider) :
+    public GetProtestsFromEventHandler(ILogger<GetProtestsFromEventHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetProtestsFromEventRequest>> validators) :
         base(logger, dbContext, validators)
     {
-        this.leagueProvider = leagueProvider;
     }
 
     public async Task<IEnumerable<ProtestModel>> Handle(GetProtestsFromEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var league = await GetLeagueEntityAsync(leagueProvider.LeagueId, cancellationToken)
+        var league = await GetCurrentLeagueEntityAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();
         var isSteward = request.User.IsInRole(LeagueRoles.Admin, LeagueRoles.Steward);
 

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetProtestsFromEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetProtestsFromEventHandler.cs
@@ -1,6 +1,7 @@
 ﻿using iRLeagueApiCore.Common.Enums;
 using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
@@ -9,15 +10,18 @@ public record GetProtestsFromEventRequest(LeagueUser User, long EventId) : IRequ
 public class GetProtestsFromEventHandler : ProtestsHandlerBase<GetProtestsFromEventHandler, GetProtestsFromEventRequest>, IRequestHandler<GetProtestsFromEventRequest, 
     IEnumerable<ProtestModel>>
 {
-    public GetProtestsFromEventHandler(ILogger<GetProtestsFromEventHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetProtestsFromEventRequest>> validators) : 
+    private readonly ILeagueProvider leagueProvider;
+
+    public GetProtestsFromEventHandler(ILogger<GetProtestsFromEventHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<GetProtestsFromEventRequest>> validators, ILeagueProvider leagueProvider) :
         base(logger, dbContext, validators)
     {
+        this.leagueProvider = leagueProvider;
     }
 
     public async Task<IEnumerable<ProtestModel>> Handle(GetProtestsFromEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var league = await GetLeagueEntityAsync(cancellationToken)
+        var league = await GetLeagueEntityAsync(leagueProvider.LeagueId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         var isSteward = request.User.IsInRole(LeagueRoles.Admin, LeagueRoles.Steward);
 

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewCommentHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewCommentHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record GetReviewCommentRequest(long LeagueId, long CommentId) : IRequest<ReviewCommentModel>;
+public record GetReviewCommentRequest(long CommentId) : IRequest<ReviewCommentModel>;
 
 public sealed class GetReviewCommentHandler : CommentHandlerBase<GetReviewCommentHandler, GetReviewCommentRequest>,
     IRequestHandler<GetReviewCommentRequest, ReviewCommentModel>
@@ -15,7 +15,7 @@ public sealed class GetReviewCommentHandler : CommentHandlerBase<GetReviewCommen
     public async Task<ReviewCommentModel> Handle(GetReviewCommentRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getComment = await MapToReviewCommentModelAsync(request.LeagueId, request.CommentId, cancellationToken)
+        var getComment = await MapToReviewCommentModelAsync(request.CommentId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getComment;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record GetReviewRequest(long LeagueId, long ReviewId, bool IncludeComments) : IRequest<ReviewModel>;
+public record GetReviewRequest(long ReviewId, bool IncludeComments) : IRequest<ReviewModel>;
 
 public sealed class GetReviewHandler : ReviewsHandlerBase<GetReviewHandler, GetReviewRequest>, IRequestHandler<GetReviewRequest, ReviewModel>
 {
@@ -14,7 +14,7 @@ public sealed class GetReviewHandler : ReviewsHandlerBase<GetReviewHandler, GetR
     public async Task<ReviewModel> Handle(GetReviewRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getReview = await MapToReviewModel(request.LeagueId, request.ReviewId, request.IncludeComments, cancellationToken)
+        var getReview = await MapToReviewModel(request.ReviewId, request.IncludeComments, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getReview;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewsFromEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewsFromEventHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Extensions;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record GetReviewsFromEventRequest(long LeagueId, long EventId, bool IncludeComments) : IRequest<IEnumerable<ReviewModel>>;
+public record GetReviewsFromEventRequest(long EventId, bool IncludeComments) : IRequest<IEnumerable<ReviewModel>>;
 public sealed class GetReviewsFromEventHandler : ReviewsHandlerBase<GetReviewsFromEventHandler, GetReviewsFromEventRequest>,
     IRequestHandler<GetReviewsFromEventRequest, IEnumerable<ReviewModel>>
 {
@@ -15,14 +15,13 @@ public sealed class GetReviewsFromEventHandler : ReviewsHandlerBase<GetReviewsFr
     public async Task<IEnumerable<ReviewModel>> Handle(GetReviewsFromEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getReviews = await MapToGetReviewsFromEventAsync(request.LeagueId, request.EventId, request.IncludeComments, cancellationToken);
+        var getReviews = await MapToGetReviewsFromEventAsync(request.EventId, request.IncludeComments, cancellationToken);
         return getReviews.OrderBy(x => x.SessionNr).ThenBy(x => x.IncidentNr);
     }
 
-    private async Task<IEnumerable<ReviewModel>> MapToGetReviewsFromEventAsync(long leagueId, long EventId, bool includeComments, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ReviewModel>> MapToGetReviewsFromEventAsync(long EventId, bool includeComments, CancellationToken cancellationToken)
     {
         return (await dbContext.IncidentReviews
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.Session.EventId == EventId)
             .Select(MapToReviewModelExpression(includeComments))
             .ToListAsync(cancellationToken))

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewsFromSessionHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetReviewsFromSessionHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Extensions;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record GetReviewsFromSessionRequest(long LeagueId, long SessionId, bool IncludeComments) : IRequest<IEnumerable<ReviewModel>>;
+public record GetReviewsFromSessionRequest(long SessionId, bool IncludeComments) : IRequest<IEnumerable<ReviewModel>>;
 public sealed class GetReviewsFromSessionHandler : ReviewsHandlerBase<GetReviewsFromSessionHandler, GetReviewsFromSessionRequest>,
     IRequestHandler<GetReviewsFromSessionRequest, IEnumerable<ReviewModel>>
 {
@@ -15,14 +15,13 @@ public sealed class GetReviewsFromSessionHandler : ReviewsHandlerBase<GetReviews
     public async Task<IEnumerable<ReviewModel>> Handle(GetReviewsFromSessionRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getReviews = await MapToGetReviewsFromSessionAsync(request.LeagueId, request.SessionId, request.IncludeComments, cancellationToken);
+        var getReviews = await MapToGetReviewsFromSessionAsync(request.SessionId, request.IncludeComments, cancellationToken);
         return getReviews;
     }
 
-    private async Task<IEnumerable<ReviewModel>> MapToGetReviewsFromSessionAsync(long leagueId, long sessionId, bool includeComments, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ReviewModel>> MapToGetReviewsFromSessionAsync(long sessionId, bool includeComments, CancellationToken cancellationToken)
     {
         return (await dbContext.IncidentReviews
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SessionId == sessionId)
             .Select(MapToReviewModelExpression(includeComments))
             .ToListAsync(cancellationToken))

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/GetVoteCategoryHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/GetVoteCategoryHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record GetVoteCategoryRequest(long LeagueId, long CatId) : IRequest<VoteCategoryModel>;
+public record GetVoteCategoryRequest(long CatId) : IRequest<VoteCategoryModel>;
 
 public class GetVoteCategoryHandler : VoteCategoriesHandlerBase<GetVoteCategoryHandler, GetVoteCategoryRequest>, 
     IRequestHandler<GetVoteCategoryRequest, VoteCategoryModel>
@@ -15,7 +15,7 @@ public class GetVoteCategoryHandler : VoteCategoriesHandlerBase<GetVoteCategoryH
     public async Task<VoteCategoryModel> Handle(GetVoteCategoryRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getVoteCategory = await MapToVoteCategoryModel(request.LeagueId, request.CatId, cancellationToken)
+        var getVoteCategory = await MapToVoteCategoryModel(request.CatId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getVoteCategory;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/PostReviewCommentToReviewHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/PostReviewCommentToReviewHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record PostReviewCommentToReviewRequest(long LeagueId, long ReviewId, LeagueUser User, PostReviewCommentModel Model) : IRequest<ReviewCommentModel>;
+public record PostReviewCommentToReviewRequest(long ReviewId, LeagueUser User, PostReviewCommentModel Model) : IRequest<ReviewCommentModel>;
 
 public sealed class PostReviewCommentToReviewHandler : CommentHandlerBase<PostReviewCommentToReviewHandler, PostReviewCommentToReviewRequest>,
     IRequestHandler<PostReviewCommentToReviewRequest, ReviewCommentModel>
@@ -16,19 +16,18 @@ public sealed class PostReviewCommentToReviewHandler : CommentHandlerBase<PostRe
     public async Task<ReviewCommentModel> Handle(PostReviewCommentToReviewRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var postComment = await CreateCommentEntityOnReviewAsync(request.LeagueId, request.ReviewId, request.User, cancellationToken);
+        var postComment = await CreateCommentEntityOnReviewAsync(request.ReviewId, request.User, cancellationToken);
         postComment = await MapToReviewCommentEntityAsync(request.User, request.Model, postComment, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getComment = await MapToReviewCommentModelAsync(postComment.LeagueId, postComment.CommentId, cancellationToken)
+        var getComment = await MapToReviewCommentModelAsync(postComment.CommentId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getComment;
     }
 
-    private async Task<ReviewCommentEntity> CreateCommentEntityOnReviewAsync(long leagueId, long reviewId, LeagueUser user,
+    private async Task<ReviewCommentEntity> CreateCommentEntityOnReviewAsync(long reviewId, LeagueUser user,
         CancellationToken cancellationToken)
     {
         var review = await dbContext.IncidentReviews
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ReviewId == reviewId)
             .FirstOrDefaultAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/PostVoteCategoryHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/PostVoteCategoryHandler.cs
@@ -4,7 +4,7 @@ using Microsoft.OpenApi.Any;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record PostVoteCategoryRequest(long LeagueId, PostVoteCategoryModel Model) : IRequest<VoteCategoryModel>;
+public record PostVoteCategoryRequest(PostVoteCategoryModel Model) : IRequest<VoteCategoryModel>;
 
 public sealed class PostVoteCategoryHandler : VoteCategoriesHandlerBase<PostVoteCategoryHandler, PostVoteCategoryRequest>, 
     IRequestHandler<PostVoteCategoryRequest, VoteCategoryModel>
@@ -17,18 +17,17 @@ public sealed class PostVoteCategoryHandler : VoteCategoriesHandlerBase<PostVote
     public async Task<VoteCategoryModel> Handle(PostVoteCategoryRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var postVoteCategory = await CreateVoteCategoryEntityAsync(request.LeagueId, cancellationToken);
+        var postVoteCategory = await CreateVoteCategoryEntityAsync(cancellationToken);
         postVoteCategory = await MapToVoteCategoryEntityAsync(request.Model, postVoteCategory, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getVoteCategory = await MapToVoteCategoryModel(request.LeagueId, postVoteCategory.CatId, cancellationToken)
+        var getVoteCategory = await MapToVoteCategoryModel(postVoteCategory.CatId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource not found");
         return getVoteCategory;
     }
 
-    private async Task<VoteCategoryEntity> CreateVoteCategoryEntityAsync(long leagueId, CancellationToken cancellationToken)
+    private async Task<VoteCategoryEntity> CreateVoteCategoryEntityAsync(CancellationToken cancellationToken)
     {
         var league = await dbContext.Leagues
-            .Where(x => x.Id == leagueId)
             .FirstOrDefaultAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();
         var voteCategory = new VoteCategoryEntity();

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/ProtestsHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/ProtestsHandlerBase.cs
@@ -11,41 +11,37 @@ public class ProtestsHandlerBase<THandler, TRequest> : HandlerBase<THandler, TRe
     {
     }
 
-    protected virtual async Task<ProtestEntity?> GetProtestEntityAsync(long leagueId, long protestId, CancellationToken cancellationToken)
+    protected virtual async Task<ProtestEntity?> GetProtestEntityAsync(long protestId, CancellationToken cancellationToken)
     {
         return await dbContext.Protests
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ProtestId == protestId)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    protected virtual async Task<ProtestEntity> MapToProtestEntity(long leagueId, LeagueUser user, PostProtestModel model, ProtestEntity entity, CancellationToken cancellationToken)
+    protected virtual async Task<ProtestEntity> MapToProtestEntity(LeagueUser user, PostProtestModel model, ProtestEntity entity, CancellationToken cancellationToken)
     {
         entity.Author = await dbContext.LeagueMembers
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.MemberId == model.AuthorMemberId)
             .FirstAsync(cancellationToken);
         entity.Corner = model.Corner;
         entity.FullDescription = model.FullDescription;
         entity.OnLap = model.OnLap;
-        entity.InvolvedMembers = await MapToLeagueMemberList(leagueId, model.InvolvedMembers.Select(x => x.MemberId), entity.InvolvedMembers, cancellationToken);
+        entity.InvolvedMembers = await MapToLeagueMemberList(model.InvolvedMembers.Select(x => x.MemberId), entity.InvolvedMembers, cancellationToken);
         return entity;
     }
 
-    protected virtual async Task<ICollection<LeagueMemberEntity>> MapToLeagueMemberList(long leagueId, IEnumerable<long> involvedMemberIds, 
+    protected virtual async Task<ICollection<LeagueMemberEntity>> MapToLeagueMemberList(IEnumerable<long> involvedMemberIds, 
         ICollection<LeagueMemberEntity> involvedMembers, CancellationToken cancellationToken)
     {
         var members = await dbContext.LeagueMembers
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => involvedMemberIds.Contains(x.MemberId))
             .ToListAsync(cancellationToken);
         return members;
     }
 
-    protected virtual async Task<ProtestModel?> MapToProtestModel(long leagueId, long protestId, bool includeAuthor, CancellationToken cancellationToken)
+    protected virtual async Task<ProtestModel?> MapToProtestModel(long protestId, bool includeAuthor, CancellationToken cancellationToken)
     {
         return await dbContext.Protests
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ProtestId == protestId)
             .Select(MapToProtestModelExpression(includeAuthor))
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/PutReviewCommentHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/PutReviewCommentHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record PutReviewCommentRequest(long LeagueId, long CommentId, LeagueUser User, PutReviewCommentModel Model) : IRequest<ReviewCommentModel>;
+public record PutReviewCommentRequest(long CommentId, LeagueUser User, PutReviewCommentModel Model) : IRequest<ReviewCommentModel>;
 
 public sealed class PutReviewCommentHandler : CommentHandlerBase<PutReviewCommentHandler, PutReviewCommentRequest>,
     IRequestHandler<PutReviewCommentRequest, ReviewCommentModel>
@@ -16,11 +16,11 @@ public sealed class PutReviewCommentHandler : CommentHandlerBase<PutReviewCommen
     public async Task<ReviewCommentModel> Handle(PutReviewCommentRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putComment = await GetCommentEntityAsync(request.LeagueId, request.CommentId, cancellationToken)
+        var putComment = await GetCommentEntityAsync(request.CommentId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putComment = await MapToReviewCommentEntityAsync(request.User, request.Model, putComment, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getComment = await MapToReviewCommentModelAsync(putComment.LeagueId, putComment.CommentId, cancellationToken)
+        var getComment = await MapToReviewCommentModelAsync(putComment.CommentId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getComment;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/PutReviewHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/PutReviewHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record PutReviewRequest(long LeagueId, long ReviewId, LeagueUser User, PutReviewModel Model) : IRequest<ReviewModel>;
+public record PutReviewRequest(long ReviewId, LeagueUser User, PutReviewModel Model) : IRequest<ReviewModel>;
 
 public sealed class PutReviewHandler : ReviewsHandlerBase<PutReviewHandler, PutReviewRequest>, IRequestHandler<PutReviewRequest, ReviewModel>
 {
@@ -20,11 +20,11 @@ public sealed class PutReviewHandler : ReviewsHandlerBase<PutReviewHandler, PutR
     public async Task<ReviewModel> Handle(PutReviewRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putReview = await GetReviewEntity(request.LeagueId, request.ReviewId, cancellationToken)
+        var putReview = await GetReviewEntity(request.ReviewId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putReview = await MapToReviewEntity(request.User, request.Model, putReview, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getReview = await MapToReviewModel(putReview.LeagueId, putReview.ReviewId, includeComments, cancellationToken)
+        var getReview = await MapToReviewModel(putReview.ReviewId, includeComments, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getReview;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/PutVoteCategoryHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/PutVoteCategoryHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Reviews;
 
-public record PutVoteCategoryRequest(long LeagueId, long CatId, PutVoteCategoryModel Model) : IRequest<VoteCategoryModel>;
+public record PutVoteCategoryRequest(long CatId, PutVoteCategoryModel Model) : IRequest<VoteCategoryModel>;
 
 public class PutVoteCategoryHandler : VoteCategoriesHandlerBase<PutVoteCategoryHandler, PutVoteCategoryRequest>, 
     IRequestHandler<PutVoteCategoryRequest, VoteCategoryModel>
@@ -16,11 +16,11 @@ public class PutVoteCategoryHandler : VoteCategoriesHandlerBase<PutVoteCategoryH
     public async Task<VoteCategoryModel> Handle(PutVoteCategoryRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putVoteCategory = await GetVoteCategoryEntityAsync(request.LeagueId, request.CatId, cancellationToken)
+        var putVoteCategory = await GetVoteCategoryEntityAsync(request.CatId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putVoteCategory = await MapToVoteCategoryEntityAsync(request.Model, putVoteCategory, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getVoteCategory = await MapToVoteCategoryModel(request.LeagueId, putVoteCategory.CatId, cancellationToken)
+        var getVoteCategory = await MapToVoteCategoryModel(putVoteCategory.CatId, cancellationToken)
             ?? throw new InvalidOperationException("Updated resource not found");
         return getVoteCategory;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/ReviewsHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/ReviewsHandlerBase.cs
@@ -12,13 +12,12 @@ public class ReviewsHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
     {
     }
 
-    protected virtual async Task<IncidentReviewEntity?> GetReviewEntity(long leagueId, long reviewId, CancellationToken cancellationToken)
+    protected virtual async Task<IncidentReviewEntity?> GetReviewEntity(long reviewId, CancellationToken cancellationToken)
     {
         return await dbContext.IncidentReviews
             .Include(x => x.InvolvedMembers)
             .Include(x => x.AcceptedReviewVotes)
                 .ThenInclude(x => x.ReviewPenaltys)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ReviewId == reviewId)
             .FirstOrDefaultAsync(cancellationToken);
     }
@@ -73,10 +72,9 @@ public class ReviewsHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
         return voteEntity;
     }
 
-    protected virtual async Task<ReviewModel?> MapToReviewModel(long leagueId, long reviewId, bool includeComments, CancellationToken cancellationToken)
+    protected virtual async Task<ReviewModel?> MapToReviewModel(long reviewId, bool includeComments, CancellationToken cancellationToken)
     {
         var query = dbContext.IncidentReviews
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ReviewId == reviewId)
             .Select(MapToReviewModelExpression(includeComments));
         return await query.FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Reviews/VoteCategoriesHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Reviews/VoteCategoriesHandlerBase.cs
@@ -10,18 +10,16 @@ public class VoteCategoriesHandlerBase<THandler, TRequest> : HandlerBase<THandle
     {
     }
 
-    protected virtual async Task<VoteCategoryEntity?> GetVoteCategoryEntityAsync(long leagueId, long catId, CancellationToken cancellationToken)
+    protected virtual async Task<VoteCategoryEntity?> GetVoteCategoryEntityAsync(long catId, CancellationToken cancellationToken)
     {
         return await dbContext.VoteCategories
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.CatId == catId)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    protected virtual async Task<IEnumerable<VoteCategoryEntity>> GetCategoryEntitiesAsync(long leagueId, CancellationToken cancellationToken)
+    protected virtual async Task<IEnumerable<VoteCategoryEntity>> GetCategoryEntitiesAsync(CancellationToken cancellationToken)
     {
         return await dbContext.VoteCategories
-            .Where(x => x.LeagueId == leagueId)
             .ToListAsync(cancellationToken);
     }
 
@@ -33,10 +31,9 @@ public class VoteCategoriesHandlerBase<THandler, TRequest> : HandlerBase<THandle
         return await Task.FromResult(target);
     }
 
-    protected virtual async Task<VoteCategoryModel?> MapToVoteCategoryModel(long leagueId, long catId, CancellationToken cancellationToken)
+    protected virtual async Task<VoteCategoryModel?> MapToVoteCategoryModel(long catId, CancellationToken cancellationToken)
     {
         return await dbContext.VoteCategories
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.CatId == catId)
             .Select(MapToVoteCategoryModelExpression)
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/DeleteScheduleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/DeleteScheduleHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Schedules;
 
-public record DeleteScheduleRequest(long LeagueId, long ScheduleId) : IRequest;
+public record DeleteScheduleRequest(long ScheduleId) : IRequest;
 
 public sealed class DeleteScheduleHandler : ScheduleHandlerBase<DeleteScheduleHandler, DeleteScheduleRequest>, IRequestHandler<DeleteScheduleRequest>
 {
@@ -12,15 +12,14 @@ public sealed class DeleteScheduleHandler : ScheduleHandlerBase<DeleteScheduleHa
     public async Task<Unit> Handle(DeleteScheduleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        await DeleteSchedule(request.LeagueId, request.ScheduleId, cancellationToken);
+        await DeleteSchedule(request.ScheduleId, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         return Unit.Value;
     }
 
-    private async Task DeleteSchedule(long leagueId, long scheduleId, CancellationToken cancellationToken)
+    private async Task DeleteSchedule(long scheduleId, CancellationToken cancellationToken)
     {
         var schedule = await dbContext.Schedules
-            .Where(x => x.LeagueId == leagueId)
             .SingleOrDefaultAsync(x => x.ScheduleId == scheduleId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Remove(schedule);

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/GetScheduleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/GetScheduleHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Schedules;
 
-public record GetScheduleRequest(long LeagueId, long ScheduleId) : IRequest<ScheduleModel>;
+public record GetScheduleRequest(long ScheduleId) : IRequest<ScheduleModel>;
 
 public sealed class GetScheduleHandler : ScheduleHandlerBase<GetScheduleHandler, GetScheduleRequest>,
     IRequestHandler<GetScheduleRequest, ScheduleModel>
@@ -14,7 +14,7 @@ public sealed class GetScheduleHandler : ScheduleHandlerBase<GetScheduleHandler,
     public async Task<ScheduleModel> Handle(GetScheduleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getSchedule = await MapToGetScheduleModelAsync(request.LeagueId, request.ScheduleId, cancellationToken)
+        var getSchedule = await MapToGetScheduleModelAsync(request.ScheduleId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getSchedule;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/GetSchedulesFromSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/GetSchedulesFromSeasonHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Schedules;
 
-public record GetSchedulesFromSeasonRequest(long LeagueId, long SeasonId) : IRequest<IEnumerable<ScheduleModel>>;
+public record GetSchedulesFromSeasonRequest(long SeasonId) : IRequest<IEnumerable<ScheduleModel>>;
 
 public sealed class GetSchedulesFromSeasonHandler : ScheduleHandlerBase<GetSchedulesFromSeasonRequest, GetSchedulesFromSeasonRequest>,
     IRequestHandler<GetSchedulesFromSeasonRequest, IEnumerable<ScheduleModel>>
@@ -15,14 +15,13 @@ public sealed class GetSchedulesFromSeasonHandler : ScheduleHandlerBase<GetSched
     public async Task<IEnumerable<ScheduleModel>> Handle(GetSchedulesFromSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getSchedules = await MapToGetScheduleModelsAsync(request.LeagueId, request.SeasonId, cancellationToken);
+        var getSchedules = await MapToGetScheduleModelsAsync(request.SeasonId, cancellationToken);
         return getSchedules;
     }
 
-    private async Task<IEnumerable<ScheduleModel>> MapToGetScheduleModelsAsync(long leagueId, long seasonId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ScheduleModel>> MapToGetScheduleModelsAsync(long seasonId, CancellationToken cancellationToken)
     {
         return await dbContext.Schedules
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SeasonId == seasonId)
             .Select(MapToGetScheduleModelExpression)
             .ToListAsync();

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/GetSchedulesHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/GetSchedulesHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Schedules;
 
-public record GetSchedulesRequest(long LeagueId) : IRequest<IEnumerable<ScheduleModel>>;
+public record GetSchedulesRequest() : IRequest<IEnumerable<ScheduleModel>>;
 
 public sealed class GetSchedulesHandler : ScheduleHandlerBase<GetSchedulesHandler, GetSchedulesRequest>, IRequestHandler<GetSchedulesRequest, IEnumerable<ScheduleModel>>
 {
@@ -13,7 +13,7 @@ public sealed class GetSchedulesHandler : ScheduleHandlerBase<GetSchedulesHandle
     public async Task<IEnumerable<ScheduleModel>> Handle(GetSchedulesRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getSchedules = await MapToGetScheduleModelsAsync(request.LeagueId, cancellationToken);
+        var getSchedules = await MapToGetScheduleModelsAsync(cancellationToken);
         if (getSchedules.Count() == 0)
         {
             throw new ResourceNotFoundException();
@@ -21,10 +21,9 @@ public sealed class GetSchedulesHandler : ScheduleHandlerBase<GetSchedulesHandle
         return getSchedules;
     }
 
-    private async Task<IEnumerable<ScheduleModel>> MapToGetScheduleModelsAsync(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<ScheduleModel>> MapToGetScheduleModelsAsync(CancellationToken cancellationToken)
     {
         return await dbContext.Schedules
-            .Where(x => x.LeagueId == leagueId)
             .Select(MapToGetScheduleModelExpression)
             .ToListAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/PostScheduleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/PostScheduleHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Schedules;
 
-public record PostScheduleRequest(long LeagueId, long seasonId, LeagueUser User, PostScheduleModel Model) : IRequest<ScheduleModel>;
+public record PostScheduleRequest(long seasonId, LeagueUser User, PostScheduleModel Model) : IRequest<ScheduleModel>;
 
 public sealed class PostScheduleHandler : ScheduleHandlerBase<PostScheduleHandler, PostScheduleRequest>,
     IRequestHandler<PostScheduleRequest, ScheduleModel>
@@ -15,15 +15,15 @@ public sealed class PostScheduleHandler : ScheduleHandlerBase<PostScheduleHandle
     public async Task<ScheduleModel> Handle(PostScheduleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var postSchedule = await CreateScheduleEntityAsync(request.LeagueId, request.seasonId, request.User, cancellationToken);
+        var postSchedule = await CreateScheduleEntityAsync(request.seasonId, request.User, cancellationToken);
         postSchedule = MapToScheduleEntity(request.User, request.Model, postSchedule);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getSchedule = await MapToGetScheduleModelAsync(request.LeagueId, postSchedule.ScheduleId, cancellationToken)
+        var getSchedule = await MapToGetScheduleModelAsync(postSchedule.ScheduleId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getSchedule;
     }
 
-    private async Task<ScheduleEntity> CreateScheduleEntityAsync(long leagueId, long seasonId, LeagueUser user, CancellationToken cancellationToken)
+    private async Task<ScheduleEntity> CreateScheduleEntityAsync(long seasonId, LeagueUser user, CancellationToken cancellationToken)
     {
         var scheduleEntity = new ScheduleEntity()
         {
@@ -32,7 +32,6 @@ public sealed class PostScheduleHandler : ScheduleHandlerBase<PostScheduleHandle
             CreatedOn = DateTime.UtcNow
         };
         var season = await dbContext.Seasons
-            .Where(x => x.LeagueId == leagueId)
             .SingleOrDefaultAsync(x => x.SeasonId == seasonId)
             ?? throw new ResourceNotFoundException();
         season.Schedules.Add(scheduleEntity);

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/PutScheduleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/PutScheduleHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Schedules;
 
-public record PutScheduleRequest(long LeagueId, LeagueUser User, long ScheduleId, PutScheduleModel Model) : IRequest<ScheduleModel>;
+public record PutScheduleRequest(LeagueUser User, long ScheduleId, PutScheduleModel Model) : IRequest<ScheduleModel>;
 
 public sealed class PutScheduleHandler : ScheduleHandlerBase<PutScheduleHandler, PutScheduleRequest>,
     IRequestHandler<PutScheduleRequest, ScheduleModel>
@@ -15,11 +15,11 @@ public sealed class PutScheduleHandler : ScheduleHandlerBase<PutScheduleHandler,
     public async Task<ScheduleModel> Handle(PutScheduleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putSchedule = await GetScheduleEntityAsync(request.LeagueId, request.ScheduleId, cancellationToken)
+        var putSchedule = await GetScheduleEntityAsync(request.ScheduleId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putSchedule = MapToScheduleEntity(request.User, request.Model, putSchedule);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getSchedule = await MapToGetScheduleModelAsync(request.LeagueId, request.ScheduleId, cancellationToken)
+        var getSchedule = await MapToGetScheduleModelAsync(request.ScheduleId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getSchedule;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Schedules/ScheduleHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Schedules/ScheduleHandlerBase.cs
@@ -21,10 +21,9 @@ public class ScheduleHandlerBase<THandler, TRequest> : HandlerBase<THandler, TRe
         return target;
     }
 
-    protected virtual async Task<ScheduleModel?> MapToGetScheduleModelAsync(long leagueId, long scheduleId, CancellationToken cancellationToken)
+    protected virtual async Task<ScheduleModel?> MapToGetScheduleModelAsync(long scheduleId, CancellationToken cancellationToken)
     {
         return await dbContext.Schedules
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ScheduleId == scheduleId)
             .Select(MapToGetScheduleModelExpression)
             .SingleOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/DeletePointRuleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/DeletePointRuleHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record DeletePointRuleRequest(long LeagueId, long PointRuleId) : IRequest;
+public record DeletePointRuleRequest(long PointRuleId) : IRequest;
 
 public sealed class DeletePointRuleHandler : PointRuleHandlerBase<DeletePointRuleHandler, DeletePointRuleRequest>,
     IRequestHandler<DeletePointRuleRequest, Unit>
@@ -13,7 +13,7 @@ public sealed class DeletePointRuleHandler : PointRuleHandlerBase<DeletePointRul
     public async Task<Unit> Handle(DeletePointRuleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deletePointRule = await GetPointRuleEntityAsync(request.LeagueId, request.PointRuleId, cancellationToken)
+        var deletePointRule = await GetPointRuleEntityAsync(request.PointRuleId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.PointRules.Remove(deletePointRule);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/DeleteScoringHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/DeleteScoringHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record DeleteScoringRequest(long LeagueId, long ScoringId) : IRequest;
+public record DeleteScoringRequest(long ScoringId) : IRequest;
 
 public sealed class DeleteScoringHandler : ScoringHandlerBase<DeleteScoringHandler, DeleteScoringRequest>, IRequestHandler<DeleteScoringRequest>
 {

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/DeleteScoringHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/DeleteScoringHandler.cs
@@ -11,7 +11,7 @@ public sealed class DeleteScoringHandler : ScoringHandlerBase<DeleteScoringHandl
     public async Task<Unit> Handle(DeleteScoringRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var scoring = await GetScoringEntityAsync(request.LeagueId, request.ScoringId) ?? throw new ResourceNotFoundException();
+        var scoring = await GetScoringEntityAsync(request.ScoringId) ?? throw new ResourceNotFoundException();
         dbContext.Scorings.Remove(scoring);
         await dbContext.SaveChangesAsync();
         _logger.LogInformation("Removed scoring {ScoringId} inside league {LeagueId} from database",

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/GetPointRuleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/GetPointRuleHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record GetPointRuleRequest(long LeagueId, long PointRuleId) : IRequest<PointRuleModel>;
+public record GetPointRuleRequest(long PointRuleId) : IRequest<PointRuleModel>;
 
 public sealed class GetPointRuleHandler : PointRuleHandlerBase<GetPointRuleHandler, GetPointRuleRequest>,
     IRequestHandler<GetPointRuleRequest, PointRuleModel>
@@ -15,7 +15,7 @@ public sealed class GetPointRuleHandler : PointRuleHandlerBase<GetPointRuleHandl
     public async Task<PointRuleModel> Handle(GetPointRuleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getPointRule = await MapToPointRuleModel(request.LeagueId, request.PointRuleId, cancellationToken)
+        var getPointRule = await MapToPointRuleModel(request.PointRuleId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getPointRule;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/GetScoringHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/GetScoringHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record GetScoringRequest(long LeagueId, long ScoringId) : IRequest<ScoringModel>;
+public record GetScoringRequest(long ScoringId) : IRequest<ScoringModel>;
 
 public sealed class GetScoringHandler : ScoringHandlerBase<GetScoringHandler, GetScoringRequest>, IRequestHandler<GetScoringRequest, ScoringModel>
 {
@@ -14,6 +14,6 @@ public sealed class GetScoringHandler : ScoringHandlerBase<GetScoringHandler, Ge
     public async Task<ScoringModel> Handle(GetScoringRequest request, CancellationToken cancellationToken = default)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        return await MapToGetScoringModelAsync(request.LeagueId, request.ScoringId) ?? throw new ResourceNotFoundException();
+        return await MapToGetScoringModelAsync(request.ScoringId, cancellationToken) ?? throw new ResourceNotFoundException();
     }
 }

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/GetScoringsHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/GetScoringsHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record GetScoringsRequest(long LeagueId) : IRequest<IEnumerable<ScoringModel>>;
+public record GetScoringsRequest() : IRequest<IEnumerable<ScoringModel>>;
 
 public sealed class GetScoringsHandler : ScoringHandlerBase<GetScoringsHandler, GetScoringsRequest>, IRequestHandler<GetScoringsRequest, IEnumerable<ScoringModel>>
 {
@@ -14,14 +14,13 @@ public sealed class GetScoringsHandler : ScoringHandlerBase<GetScoringsHandler, 
     public async Task<IEnumerable<ScoringModel>> Handle(GetScoringsRequest request, CancellationToken cancellationToken = default)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        return await MapToGetScoringModelsAsync(request.LeagueId);
+        return await MapToGetScoringModelsAsync(cancellationToken);
     }
 
-    private async Task<IEnumerable<ScoringModel>> MapToGetScoringModelsAsync(long leagueId, CancellationToken cancellationToken = default)
+    private async Task<IEnumerable<ScoringModel>> MapToGetScoringModelsAsync(CancellationToken cancellationToken = default)
     {
         return await dbContext.Scorings
-            .Where(x => x.LeagueId == leagueId)
             .Select(MapToGetScoringModelExpression)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 }

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/PointRuleHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/PointRuleHandlerBase.cs
@@ -11,10 +11,9 @@ public class PointRuleHandlerBase<THandler, TRequest> : HandlerBase<THandler, TR
     {
     }
 
-    protected virtual async Task<PointRuleEntity?> GetPointRuleEntityAsync(long leagueId, long pointRuleId, CancellationToken cancellationToken)
+    protected virtual async Task<PointRuleEntity?> GetPointRuleEntityAsync(long pointRuleId, CancellationToken cancellationToken)
     {
         return await dbContext.PointRules
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.PointRuleId == pointRuleId)
             .FirstOrDefaultAsync(cancellationToken);
     }
@@ -33,10 +32,9 @@ public class PointRuleHandlerBase<THandler, TRequest> : HandlerBase<THandler, TR
         return await Task.FromResult(pointRuleEntity);
     }
 
-    protected virtual async Task<PointRuleModel?> MapToPointRuleModel(long leagueId, long pointRuleId, CancellationToken cancellationToken)
+    protected virtual async Task<PointRuleModel?> MapToPointRuleModel(long pointRuleId, CancellationToken cancellationToken)
     {
         return await dbContext.PointRules
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.PointRuleId == pointRuleId)
             .Select(MapToPointRuleModelExpression)
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/PostPointRuleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/PostPointRuleHandler.cs
@@ -9,13 +9,10 @@ public record PostPointRuleRequest(LeagueUser User, PostPointRuleModel Model) : 
 public sealed class PostPointRuleHandler : PointRuleHandlerBase<PostPointRuleHandler, PostPointRuleRequest>,
     IRequestHandler<PostPointRuleRequest, PointRuleModel>
 {
-    private readonly ILeagueProvider leagueProvider;
-
     public PostPointRuleHandler(ILogger<PostPointRuleHandler> logger, LeagueDbContext dbContext, 
-        IEnumerable<IValidator<PostPointRuleRequest>> validators, ILeagueProvider leagueProvider) 
+        IEnumerable<IValidator<PostPointRuleRequest>> validators) 
         : base(logger, dbContext, validators)
     {
-        this.leagueProvider = leagueProvider;
     }
 
     public async Task<PointRuleModel> Handle(PostPointRuleRequest request, CancellationToken cancellationToken)
@@ -31,7 +28,7 @@ public sealed class PostPointRuleHandler : PointRuleHandlerBase<PostPointRuleHan
 
     private async Task<PointRuleEntity> CreatePointRuleEntityAsync(LeagueUser user, CancellationToken cancellationToken)
     {
-        var league = await GetLeagueEntityAsync(leagueProvider.LeagueId, cancellationToken)
+        var league = await GetCurrentLeagueEntityAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();
         var pointRule = CreateVersionEntity(user, new PointRuleEntity());
         league.PointRules.Add(pointRule);

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/PostPointRuleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/PostPointRuleHandler.cs
@@ -1,5 +1,6 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
@@ -8,9 +9,13 @@ public record PostPointRuleRequest(LeagueUser User, PostPointRuleModel Model) : 
 public sealed class PostPointRuleHandler : PointRuleHandlerBase<PostPointRuleHandler, PostPointRuleRequest>,
     IRequestHandler<PostPointRuleRequest, PointRuleModel>
 {
-    public PostPointRuleHandler(ILogger<PostPointRuleHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostPointRuleRequest>> validators) :
-        base(logger, dbContext, validators)
+    private readonly ILeagueProvider leagueProvider;
+
+    public PostPointRuleHandler(ILogger<PostPointRuleHandler> logger, LeagueDbContext dbContext, 
+        IEnumerable<IValidator<PostPointRuleRequest>> validators, ILeagueProvider leagueProvider) 
+        : base(logger, dbContext, validators)
     {
+        this.leagueProvider = leagueProvider;
     }
 
     public async Task<PointRuleModel> Handle(PostPointRuleRequest request, CancellationToken cancellationToken)
@@ -26,7 +31,7 @@ public sealed class PostPointRuleHandler : PointRuleHandlerBase<PostPointRuleHan
 
     private async Task<PointRuleEntity> CreatePointRuleEntityAsync(LeagueUser user, CancellationToken cancellationToken)
     {
-        var league = await GetLeagueEntityAsync(cancellationToken)
+        var league = await GetLeagueEntityAsync(leagueProvider.LeagueId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         var pointRule = CreateVersionEntity(user, new PointRuleEntity());
         league.PointRules.Add(pointRule);

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/PutPointRuleHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/PutPointRuleHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record PutPointRuleRequest(long LeagueId, long PointRuleId, LeagueUser User, PutPointRuleModel Model) : IRequest<PointRuleModel>;
+public record PutPointRuleRequest(long PointRuleId, LeagueUser User, PutPointRuleModel Model) : IRequest<PointRuleModel>;
 
 public sealed class PutPointRuleHandler : PointRuleHandlerBase<PutPointRuleHandler, PutPointRuleRequest>,
     IRequestHandler<PutPointRuleRequest, PointRuleModel>
@@ -16,11 +16,11 @@ public sealed class PutPointRuleHandler : PointRuleHandlerBase<PutPointRuleHandl
     public async Task<PointRuleModel> Handle(PutPointRuleRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putPointRule = await GetPointRuleEntityAsync(request.LeagueId, request.PointRuleId, cancellationToken)
+        var putPointRule = await GetPointRuleEntityAsync(request.PointRuleId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         putPointRule = await MapToPointRuleEntityAsync(request.User, request.Model, putPointRule, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getPointRule = await MapToPointRuleModel(request.LeagueId, putPointRule.PointRuleId, cancellationToken)
+        var getPointRule = await MapToPointRuleModel(putPointRule.PointRuleId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getPointRule;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/PutScoringHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/PutScoringHandler.cs
@@ -15,7 +15,7 @@ public sealed class PutScoringHandler : ScoringHandlerBase<PutScoringHandler, Pu
     public async Task<ScoringModel> Handle(PutScoringRequest request, CancellationToken cancellationToken = default)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putScoring = await GetScoringEntityAsync(request.LeagueId, request.ScoringId) ?? throw new ResourceNotFoundException();
+        var putScoring = await GetScoringEntityAsync(request.ScoringId) ?? throw new ResourceNotFoundException();
         await MapToScoringEntityAsync(request.User, request.LeagueId, request.Model, putScoring);
         await dbContext.SaveChangesAsync();
         var getScoring = await MapToGetScoringModelAsync(request.LeagueId, putScoring.ScoringId)

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/PutScoringHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/PutScoringHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Scorings;
 
-public record PutScoringRequest(long LeagueId, long ScoringId, LeagueUser User, PutScoringModel Model) : IRequest<ScoringModel>;
+public record PutScoringRequest(long ScoringId, LeagueUser User, PutScoringModel Model) : IRequest<ScoringModel>;
 
 public sealed class PutScoringHandler : ScoringHandlerBase<PutScoringHandler, PutScoringRequest>, IRequestHandler<PutScoringRequest, ScoringModel>
 {
@@ -16,9 +16,9 @@ public sealed class PutScoringHandler : ScoringHandlerBase<PutScoringHandler, Pu
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
         var putScoring = await GetScoringEntityAsync(request.ScoringId) ?? throw new ResourceNotFoundException();
-        await MapToScoringEntityAsync(request.User, request.LeagueId, request.Model, putScoring);
-        await dbContext.SaveChangesAsync();
-        var getScoring = await MapToGetScoringModelAsync(request.LeagueId, putScoring.ScoringId)
+        await MapToScoringEntityAsync(request.User, request.Model, putScoring, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        var getScoring = await MapToGetScoringModelAsync(putScoring.ScoringId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getScoring;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/ScoringHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/ScoringHandlerBase.cs
@@ -40,7 +40,7 @@ public class ScoringHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
     protected virtual async Task<ScoringEntity> MapToScoringEntityAsync(LeagueUser user, long leagueId, PostScoringModel source, ScoringEntity target,
         CancellationToken cancellationToken = default)
     {
-        target.ExtScoringSource = await GetScoringEntityAsync(leagueId, source.ExtScoringSourceId, cancellationToken);
+        target.ExtScoringSource = await GetScoringEntityAsync(source.ExtScoringSourceId, cancellationToken);
         target.MaxResultsPerGroup = source.MaxResultsPerGroup;
         target.Name = source.Name;
         target.ShowResults = source.ShowResults;

--- a/src/iRLeagueApiCore.Server/Handlers/Scorings/ScoringHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Scorings/ScoringHandlerBase.cs
@@ -37,7 +37,7 @@ public class ScoringHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
             .Where(x => string.IsNullOrEmpty(x) == false) ?? new string[0];
     }
 
-    protected virtual async Task<ScoringEntity> MapToScoringEntityAsync(LeagueUser user, long leagueId, PostScoringModel source, ScoringEntity target,
+    protected virtual async Task<ScoringEntity> MapToScoringEntityAsync(LeagueUser user, PostScoringModel source, ScoringEntity target,
         CancellationToken cancellationToken = default)
     {
         target.ExtScoringSource = await GetScoringEntityAsync(source.ExtScoringSourceId, cancellationToken);
@@ -50,10 +50,9 @@ public class ScoringHandlerBase<THandler, TRequest> : HandlerBase<THandler, TReq
         return UpdateVersionEntity(user, target);
     }
 
-    protected virtual async Task<ScoringModel?> MapToGetScoringModelAsync(long leagueId, long scoringId, CancellationToken cancellationToken = default)
+    protected virtual async Task<ScoringModel?> MapToGetScoringModelAsync(long scoringId, CancellationToken cancellationToken = default)
     {
         return await dbContext.Scorings
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.ScoringId == scoringId)
             .Select(MapToGetScoringModelExpression)
             .SingleOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/DeleteSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/DeleteSeasonHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Seasons;
 
-public record DeleteSeasonRequest(long LeagueId, long SeasonId) : IRequest;
+public record DeleteSeasonRequest(long SeasonId) : IRequest;
 
 public sealed class DeleteSeasonHandler : SeasonHandlerBase<DeleteSeasonHandler, DeleteSeasonRequest>, IRequestHandler<DeleteSeasonRequest>
 {
@@ -12,12 +12,12 @@ public sealed class DeleteSeasonHandler : SeasonHandlerBase<DeleteSeasonHandler,
     public async Task<Unit> Handle(DeleteSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        await DeleteSeasonEntity(request.LeagueId, request.SeasonId, cancellationToken);
+        await DeleteSeasonEntity(request.SeasonId, cancellationToken);
         await dbContext.SaveChangesAsync();
         return Unit.Value;
     }
 
-    private async Task DeleteSeasonEntity(long leagueId, long seasonId, CancellationToken cancellationToken)
+    private async Task DeleteSeasonEntity(long seasonId, CancellationToken cancellationToken)
     {
         var deleteSeason = await dbContext.Seasons
             .Include(x => x.ChampSeasons)
@@ -26,7 +26,6 @@ public sealed class DeleteSeasonHandler : SeasonHandlerBase<DeleteSeasonHandler,
             .Include(x => x.ChampSeasons)
                 .ThenInclude(x => x.ResultConfigurations)
                     .ThenInclude(x => x.ResultFilters)
-            .Where(x => x.LeagueId == leagueId)
             .SingleOrDefaultAsync(x => x.SeasonId == seasonId)
             ?? throw new ResourceNotFoundException();
         dbContext.RemoveRange(deleteSeason.ChampSeasons.SelectMany(x => x.ResultConfigurations).SelectMany(x => x.PointFilters));

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/GetCurrentSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/GetCurrentSeasonHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Seasons;
 
-public record GetCurrentSeasonRequest(long LeagueId) : IRequest<SeasonModel>;
+public record GetCurrentSeasonRequest() : IRequest<SeasonModel>;
 
 public sealed class GetCurrentSeasonHandler : SeasonHandlerBase<GetCurrentSeasonHandler, GetCurrentSeasonRequest>,
     IRequestHandler<GetCurrentSeasonRequest, SeasonModel>
@@ -16,13 +16,12 @@ public sealed class GetCurrentSeasonHandler : SeasonHandlerBase<GetCurrentSeason
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
         var getSeasonId = await dbContext.Events
-            .Where(x => x.LeagueId == request.LeagueId)
             .Where(x => x.Date < DateTime.UtcNow)
             .OrderByDescending(x => x.Date)
             .Select(x => (long?)x.Schedule.SeasonId)
             .FirstOrDefaultAsync(cancellationToken)
             ?? throw new ResourceNotFoundException();
-        var getSeason = await MapToGetSeasonModel(request.LeagueId, getSeasonId, cancellationToken)
+        var getSeason = await MapToGetSeasonModel(getSeasonId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getSeason;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/GetSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/GetSeasonHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Seasons;
 
-public record GetSeasonRequest(long LeagueId, long SeasonId) : IRequest<SeasonModel>;
+public record GetSeasonRequest(long SeasonId) : IRequest<SeasonModel>;
 
 public sealed class GetSeasonHandler : SeasonHandlerBase<GetSeasonHandler, GetSeasonRequest>, IRequestHandler<GetSeasonRequest, SeasonModel>
 {
@@ -14,7 +14,7 @@ public sealed class GetSeasonHandler : SeasonHandlerBase<GetSeasonHandler, GetSe
     public async Task<SeasonModel> Handle(GetSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getSeason = await MapToGetSeasonModel(request.LeagueId, request.SeasonId, cancellationToken)
+        var getSeason = await MapToGetSeasonModel(request.SeasonId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getSeason;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/GetSeasonsHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/GetSeasonsHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Seasons;
 
-public record GetSeasonsRequest(long LeagueId) : IRequest<IEnumerable<SeasonModel>>;
+public record GetSeasonsRequest() : IRequest<IEnumerable<SeasonModel>>;
 
 public sealed class GetSeasonsHandler : SeasonHandlerBase<GetSeasonsHandler, GetSeasonsRequest>, IRequestHandler<GetSeasonsRequest, IEnumerable<SeasonModel>>
 {
@@ -14,7 +14,7 @@ public sealed class GetSeasonsHandler : SeasonHandlerBase<GetSeasonsHandler, Get
     public async Task<IEnumerable<SeasonModel>> Handle(GetSeasonsRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getSeasons = await GetSeasonsEntityAsync(request.LeagueId, cancellationToken);
+        var getSeasons = await GetSeasonsEntityAsync(cancellationToken);
         if (getSeasons.Count() == 0)
         {
             throw new ResourceNotFoundException();
@@ -22,10 +22,9 @@ public sealed class GetSeasonsHandler : SeasonHandlerBase<GetSeasonsHandler, Get
         return getSeasons;
     }
 
-    private async Task<IEnumerable<SeasonModel>> GetSeasonsEntityAsync(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<SeasonModel>> GetSeasonsEntityAsync(CancellationToken cancellationToken)
     {
         return (await dbContext.Seasons
-            .Where(x => x.LeagueId == leagueId)
             .Select(MapToGetSeasonModelExpression)
             .ToListAsync(cancellationToken))
             .OrderBy(x => x.SeasonStart);

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/PostSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/PostSeasonHandler.cs
@@ -1,25 +1,29 @@
 ﻿using iRLeagueApiCore.Common.Models;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 
 namespace iRLeagueApiCore.Server.Handlers.Seasons;
 
-public record PostSeasonRequest(long LeagueId, LeagueUser User, PostSeasonModel Model) : IRequest<SeasonModel>;
+public record PostSeasonRequest(LeagueUser User, PostSeasonModel Model) : IRequest<SeasonModel>;
 
 public sealed class PostSeasonHandler : SeasonHandlerBase<PostSeasonHandler, PostSeasonRequest>, IRequestHandler<PostSeasonRequest, SeasonModel>
 {
-    public PostSeasonHandler(ILogger<PostSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostSeasonRequest>> validators) :
+    private readonly ILeagueProvider leagueProvider;
+
+    public PostSeasonHandler(ILogger<PostSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostSeasonRequest>> validators, ILeagueProvider leagueProvider) :
         base(logger, dbContext, validators)
     {
+        this.leagueProvider = leagueProvider;
     }
 
     public async Task<SeasonModel> Handle(PostSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
 
-        var postSeason = await CreateSeasonEntity(request.User, request.LeagueId, cancellationToken);
-        await MapToSeasonEntityAsync(request.LeagueId, request.User, request.Model, postSeason, cancellationToken);
+        var postSeason = await CreateSeasonEntity(request.User, leagueProvider.LeagueId, cancellationToken);
+        await MapToSeasonEntityAsync(request.User, request.Model, postSeason, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getSeason = await MapToGetSeasonModel(request.LeagueId, postSeason.SeasonId, cancellationToken)
+        var getSeason = await MapToGetSeasonModel(postSeason.SeasonId, cancellationToken)
             ?? throw new InvalidOperationException($"Creating season {request.Model.SeasonName} failed");
         return getSeason;
     }
@@ -27,7 +31,7 @@ public sealed class PostSeasonHandler : SeasonHandlerBase<PostSeasonHandler, Pos
     private async Task<SeasonEntity> CreateSeasonEntity(LeagueUser user, long leagueId, CancellationToken cancellationToken = default)
     {
         var league = await dbContext.Leagues
-            .SingleOrDefaultAsync(x => x.Id == leagueId) ?? throw new ResourceNotFoundException();
+            .SingleOrDefaultAsync(x => x.Id == leagueId, cancellationToken) ?? throw new ResourceNotFoundException();
         var seasonEntity = CreateVersionEntity(user, new SeasonEntity());
         league.Seasons.Add(seasonEntity);
         return seasonEntity;

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/PostSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/PostSeasonHandler.cs
@@ -8,19 +8,16 @@ public record PostSeasonRequest(LeagueUser User, PostSeasonModel Model) : IReque
 
 public sealed class PostSeasonHandler : SeasonHandlerBase<PostSeasonHandler, PostSeasonRequest>, IRequestHandler<PostSeasonRequest, SeasonModel>
 {
-    private readonly ILeagueProvider leagueProvider;
-
-    public PostSeasonHandler(ILogger<PostSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostSeasonRequest>> validators, ILeagueProvider leagueProvider) :
-        base(logger, dbContext, validators)
+    public PostSeasonHandler(ILogger<PostSeasonHandler> logger, LeagueDbContext dbContext, IEnumerable<IValidator<PostSeasonRequest>> validators) 
+        : base(logger, dbContext, validators)
     {
-        this.leagueProvider = leagueProvider;
     }
 
     public async Task<SeasonModel> Handle(PostSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
 
-        var postSeason = await CreateSeasonEntity(request.User, leagueProvider.LeagueId, cancellationToken);
+        var postSeason = await CreateSeasonEntity(request.User, dbContext.LeagueProvider.LeagueId, cancellationToken);
         await MapToSeasonEntityAsync(request.User, request.Model, postSeason, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         var getSeason = await MapToGetSeasonModel(postSeason.SeasonId, cancellationToken)

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/PutSeasonHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/PutSeasonHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Seasons;
 
-public record PutSeasonRequest(long LeagueId, LeagueUser User, long SeasonId, PutSeasonModel Model) : IRequest<SeasonModel>;
+public record PutSeasonRequest(LeagueUser User, long SeasonId, PutSeasonModel Model) : IRequest<SeasonModel>;
 
 public sealed class PutSeasonHandler : SeasonHandlerBase<PutSeasonHandler, PutSeasonRequest>, IRequestHandler<PutSeasonRequest, SeasonModel>
 {
@@ -15,11 +15,11 @@ public sealed class PutSeasonHandler : SeasonHandlerBase<PutSeasonHandler, PutSe
     public async Task<SeasonModel> Handle(PutSeasonRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putSeason = await GetSeasonEntityAsync(request.LeagueId, request.SeasonId, cancellationToken)
+        var putSeason = await GetSeasonEntityAsync(request.SeasonId, cancellationToken)
             ?? throw new ResourceNotFoundException();
-        await MapToSeasonEntityAsync(request.LeagueId, request.User, request.Model, putSeason, cancellationToken);
+        await MapToSeasonEntityAsync(request.User, request.Model, putSeason, cancellationToken);
         await dbContext.SaveChangesAsync();
-        var getSeason = await MapToGetSeasonModel(request.LeagueId, request.SeasonId, cancellationToken)
+        var getSeason = await MapToGetSeasonModel(request.SeasonId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getSeason;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Seasons/SeasonHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Seasons/SeasonHandlerBase.cs
@@ -11,20 +11,19 @@ public abstract class SeasonHandlerBase<THandler, TRequest> : HandlerBase<THandl
     {
     }
 
-    protected virtual async Task<SeasonEntity> MapToSeasonEntityAsync(long leagueId, LeagueUser user, PostSeasonModel putSeason,
+    protected virtual async Task<SeasonEntity> MapToSeasonEntityAsync(LeagueUser user, PostSeasonModel putSeason,
         SeasonEntity target, CancellationToken cancellationToken)
     {
         target.Finished = putSeason.Finished;
         target.HideCommentsBeforeVoted = putSeason.HideComments;
-        target.MainScoring = await GetScoringEntityAsync(leagueId, putSeason.MainScoringId, cancellationToken);
+        target.MainScoring = await GetScoringEntityAsync(putSeason.MainScoringId, cancellationToken);
         target.SeasonName = putSeason.SeasonName;
         return UpdateVersionEntity(user, target);
     }
 
-    protected virtual async Task<SeasonModel?> MapToGetSeasonModel(long leagueId, long seasonId, CancellationToken cancellationToken)
+    protected virtual async Task<SeasonModel?> MapToGetSeasonModel(long seasonId, CancellationToken cancellationToken)
     {
         return await dbContext.Seasons
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SeasonId == seasonId)
             .Select(MapToGetSeasonModelExpression)
             .SingleOrDefaultAsync();

--- a/src/iRLeagueApiCore.Server/Handlers/Standings/GetStandingsFromEventHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Standings/GetStandingsFromEventHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Standings;
 
-public record GetStandingsFromEventRequest(long LeagueId, long EventId) : IRequest<IEnumerable<StandingsModel>>;
+public record GetStandingsFromEventRequest(long EventId) : IRequest<IEnumerable<StandingsModel>>;
 
 public sealed class GetStandingsFromEventHandler : StandingsHandlerBase<GetStandingsFromEventHandler, GetStandingsFromEventRequest>,
     IRequestHandler<GetStandingsFromEventRequest, IEnumerable<StandingsModel>>
@@ -15,14 +15,13 @@ public sealed class GetStandingsFromEventHandler : StandingsHandlerBase<GetStand
     public async Task<IEnumerable<StandingsModel>> Handle(GetStandingsFromEventRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getStandings = await MapToStandingModelFromEventAsync(request.LeagueId, request.EventId, cancellationToken);
+        var getStandings = await MapToStandingModelFromEventAsync(request.EventId, cancellationToken);
         return getStandings;
     }
 
-    private async Task<IEnumerable<StandingsModel>> MapToStandingModelFromEventAsync(long leagueId, long eventId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<StandingsModel>> MapToStandingModelFromEventAsync(long eventId, CancellationToken cancellationToken)
     {
         var standings = await dbContext.Standings
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.EventId == eventId)
             .Select(MapToStandingModelExpression)
             .ToListAsync(cancellationToken);
@@ -30,7 +29,7 @@ public sealed class GetStandingsFromEventHandler : StandingsHandlerBase<GetStand
         {
             return standings;
         }
-        standings = (await AlignStandingResultRows(leagueId, standings.Select(x => x.SeasonId).First(), standings, cancellationToken)).ToList();
+        standings = (await AlignStandingResultRows(standings.Select(x => x.SeasonId).First(), standings, cancellationToken)).ToList();
         return standings;
     }
 }

--- a/src/iRLeagueApiCore.Server/Handlers/Standings/StandingsHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Standings/StandingsHandlerBase.cs
@@ -22,11 +22,10 @@ public class StandingsHandlerBase<THandler, TRequest> : HandlerBase<THandler, TR
     /// <param name="standings"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    protected async Task<IEnumerable<StandingsModel>> AlignStandingResultRows(long leagueId, long seasonId, IEnumerable<StandingsModel> standings,
+    protected async Task<IEnumerable<StandingsModel>> AlignStandingResultRows(long seasonId, IEnumerable<StandingsModel> standings,
         CancellationToken cancellationToken)
     {
         var events = await dbContext.Events
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.Schedule.SeasonId == seasonId)
             .OrderBy(x => x.Date)
             .ToListAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Teams/DeleteTeamHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Teams/DeleteTeamHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace iRLeagueApiCore.Server.Handlers.Teams;
 
-public record DeleteTeamRequest(long LeagueId, long TeamId) : IRequest;
+public record DeleteTeamRequest(long TeamId) : IRequest;
 
 public class DeleteTeamHandler : TeamsHandlerBase<DeleteTeamHandler, DeleteTeamRequest>, 
     IRequestHandler<DeleteTeamRequest, Unit>
@@ -13,7 +13,7 @@ public class DeleteTeamHandler : TeamsHandlerBase<DeleteTeamHandler, DeleteTeamR
     public async Task<Unit> Handle(DeleteTeamRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteTeam = await GetTeamEntity(request.LeagueId, request.TeamId, cancellationToken)
+        var deleteTeam = await GetTeamEntity(request.TeamId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         dbContext.Teams.Remove(deleteTeam);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Handlers/Teams/GetTeamHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Teams/GetTeamHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Teams;
 
-public record GetTeamRequest(long leagueId, long teamId) : IRequest<TeamModel>;
+public record GetTeamRequest(long teamId) : IRequest<TeamModel>;
 
 public class GetTeamHandler : TeamsHandlerBase<GetTeamHandler, GetTeamRequest>, 
     IRequestHandler<GetTeamRequest, TeamModel>
@@ -15,7 +15,7 @@ public class GetTeamHandler : TeamsHandlerBase<GetTeamHandler, GetTeamRequest>,
     public async Task<TeamModel> Handle(GetTeamRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getTeam = await MapToTeamModel(request.leagueId, request.teamId, cancellationToken)
+        var getTeam = await MapToTeamModel(request.teamId, cancellationToken)
             ?? throw new ResourceNotFoundException();
         return getTeam;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Teams/GetTeamsFromLeagueHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Teams/GetTeamsFromLeagueHandler.cs
@@ -2,7 +2,7 @@
 
 namespace iRLeagueApiCore.Server.Handlers.Teams;
 
-public record GetTeamsFromLeagueRequest(long LeagueId) : IRequest<IEnumerable<TeamModel>>;
+public record GetTeamsFromLeagueRequest() : IRequest<IEnumerable<TeamModel>>;
 
 public sealed class GetTeamsFromLeagueHandler : TeamsHandlerBase<GetTeamsFromLeagueHandler, GetTeamsFromLeagueRequest>,
     IRequestHandler<GetTeamsFromLeagueRequest, IEnumerable<TeamModel>>
@@ -15,14 +15,13 @@ public sealed class GetTeamsFromLeagueHandler : TeamsHandlerBase<GetTeamsFromLea
     public async Task<IEnumerable<TeamModel>> Handle(GetTeamsFromLeagueRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var getTeams = await MapToTeamModels(request.LeagueId, cancellationToken);
+        var getTeams = await MapToTeamModels(cancellationToken);
         return getTeams;
     }
 
-    private async Task<IEnumerable<TeamModel>> MapToTeamModels(long leagueId, CancellationToken cancellationToken)
+    private async Task<IEnumerable<TeamModel>> MapToTeamModels(CancellationToken cancellationToken)
     {
         return await dbContext.Teams
-            .Where(x => x.LeagueId == leagueId)
             .Select(MapToTeamModelExpression)
             .ToListAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Teams/PostTeamHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Teams/PostTeamHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Teams;
 
-public record PostTeamRequest(long LeagueId, LeagueUser User, PostTeamModel Model) : IRequest<TeamModel>;
+public record PostTeamRequest(LeagueUser User, PostTeamModel Model) : IRequest<TeamModel>;
 
 public class PostTeamHandler : TeamsHandlerBase<PostTeamHandler, PostTeamRequest>, 
     IRequestHandler<PostTeamRequest, TeamModel>
@@ -16,10 +16,10 @@ public class PostTeamHandler : TeamsHandlerBase<PostTeamHandler, PostTeamRequest
     public async Task<TeamModel> Handle(PostTeamRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var postTeam = await CreateTeamEntity(request.LeagueId, request.User, cancellationToken);
-        postTeam = await MapToTeamEntityAsync(request.LeagueId, request.User, request.Model, postTeam, cancellationToken);
+        var postTeam = await CreateTeamEntity(request.User, cancellationToken);
+        postTeam = await MapToTeamEntityAsync(request.User, request.Model, postTeam, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getTeam = await MapToTeamModel(request.LeagueId, postTeam.TeamId, cancellationToken)
+        var getTeam = await MapToTeamModel(postTeam.TeamId, cancellationToken)
             ?? throw new InvalidOperationException("Failed to fetch created team resource");
         return getTeam;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Teams/PutTeamHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Teams/PutTeamHandler.cs
@@ -3,7 +3,7 @@ using iRLeagueApiCore.Server.Models;
 
 namespace iRLeagueApiCore.Server.Handlers.Teams;
 
-public record PutTeamRequest(long LeagueId, long TeamId, LeagueUser User, PutTeamModel Model) : IRequest<TeamModel>;
+public record PutTeamRequest(long TeamId, LeagueUser User, PutTeamModel Model) : IRequest<TeamModel>;
 
 public class PutTeamHandler : TeamsHandlerBase<PutTeamHandler, PutTeamRequest>, 
     IRequestHandler<PutTeamRequest, TeamModel>
@@ -16,11 +16,11 @@ public class PutTeamHandler : TeamsHandlerBase<PutTeamHandler, PutTeamRequest>,
     public async Task<TeamModel> Handle(PutTeamRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var putTeam = await GetTeamEntity(request.LeagueId, request.TeamId, cancellationToken)
+        var putTeam = await GetTeamEntity(request.TeamId, cancellationToken)
             ?? throw new ResourceNotFoundException();
-        putTeam = await MapToTeamEntityAsync(request.LeagueId, request.User, request.Model, putTeam, cancellationToken);
+        putTeam = await MapToTeamEntityAsync(request.User, request.Model, putTeam, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
-        var getTeam = await MapToTeamModel(request.LeagueId, request.TeamId, cancellationToken)
+        var getTeam = await MapToTeamModel(request.TeamId, cancellationToken)
             ?? throw new InvalidOperationException("Created resource was not found");
         return getTeam;
     }

--- a/src/iRLeagueApiCore.Server/Handlers/Teams/TeamsHandlerBase.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Teams/TeamsHandlerBase.cs
@@ -11,19 +11,18 @@ public abstract class TeamsHandlerBase<THandler, TRequest> : HandlerBase<THandle
     {
     }
 
-    protected virtual async Task<TeamEntity?> GetTeamEntity(long leagueId, long teamId, CancellationToken cancellationToken)
+    protected virtual async Task<TeamEntity?> GetTeamEntity(long teamId, CancellationToken cancellationToken)
     {
         return await dbContext.Teams
             .Include(x => x.Members)
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.TeamId == teamId)
             .FirstOrDefaultAsync(cancellationToken);
     }
 
-    protected virtual async Task<TeamEntity> CreateTeamEntity(long leagueId, LeagueUser user, CancellationToken cancellationToken)
+    protected virtual async Task<TeamEntity> CreateTeamEntity(LeagueUser user, CancellationToken cancellationToken)
     {
+        var leagueId = dbContext.LeagueProvider.LeagueId;
         var league = await dbContext.Leagues
-            .Where(x => x.Id == leagueId)
             .FirstOrDefaultAsync(cancellationToken);
         if (league is null)
         {
@@ -37,32 +36,30 @@ public abstract class TeamsHandlerBase<THandler, TRequest> : HandlerBase<THandle
         return team;
     }
 
-    protected virtual async Task<TeamEntity> MapToTeamEntityAsync(long leagueId, LeagueUser user, PostTeamModel model, TeamEntity entity, CancellationToken cancellationToken)
+    protected virtual async Task<TeamEntity> MapToTeamEntityAsync(LeagueUser user, PostTeamModel model, TeamEntity entity, CancellationToken cancellationToken)
     {
         entity.Name = model.Name;
         entity.Profile = model.Profile;
         entity.TeamColor = model.TeamColor;
         entity.TeamHomepage = model.TeamHomepage;
-        entity.Members = await MapToTeamMemberListAsync(leagueId, model.Members, entity.Members, cancellationToken);
+        entity.Members = await MapToTeamMemberListAsync(model.Members, entity.Members, cancellationToken);
         return UpdateVersionEntity(user, entity);
     }
 
-    private async Task<ICollection<LeagueMemberEntity>> MapToTeamMemberListAsync(long leagueId, ICollection<MemberInfoModel> memberModels, 
+    private async Task<ICollection<LeagueMemberEntity>> MapToTeamMemberListAsync(ICollection<MemberInfoModel> memberModels, 
         ICollection<LeagueMemberEntity> memberEntities, CancellationToken cancellationToken)
     {
         var memberIds = memberModels.Select(x => x.MemberId);
         var leagueMembers = await dbContext.LeagueMembers
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => memberIds.Contains(x.MemberId))
             .ToListAsync(cancellationToken);
 
         return leagueMembers.ToList();
     }
 
-    protected virtual async Task<TeamModel?> MapToTeamModel(long leagueId, long teamId, CancellationToken cancellationToken)
+    protected virtual async Task<TeamModel?> MapToTeamModel(long teamId, CancellationToken cancellationToken)
     {
         return await dbContext.Teams
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => teamId == x.TeamId)
             .Select(MapToTeamModelExpression)
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Models/LeagueDbContextFactory.cs
+++ b/src/iRLeagueApiCore.Server/Models/LeagueDbContextFactory.cs
@@ -1,6 +1,8 @@
-﻿namespace iRLeagueApiCore.Server.Models;
+﻿using iRLeagueDatabaseCore;
 
-public sealed class LeagueDbContextFactory : IDbContextFactory<LeagueDbContext>
+namespace iRLeagueApiCore.Server.Models;
+
+public sealed class LeagueDbContextFactory
 {
     private readonly IConfiguration _configuration;
 
@@ -9,13 +11,13 @@ public sealed class LeagueDbContextFactory : IDbContextFactory<LeagueDbContext>
         _configuration = configuration;
     }
 
-    public LeagueDbContext CreateDbContext()
+    public LeagueDbContext CreateDbContext(ILeagueProvider leagueProvider)
     {
         var dbConnectionString = _configuration.GetConnectionString("ModelDb");
         var optionsBuilder = new DbContextOptionsBuilder<LeagueDbContext>();
         optionsBuilder.UseMySQL(dbConnectionString);
 
-        var dbContext = new LeagueDbContext(optionsBuilder.Options);
+        var dbContext = new LeagueDbContext(optionsBuilder.Options, leagueProvider);
         return dbContext;
     }
 }

--- a/src/iRLeagueApiCore.Server/Models/RequestLeagueProvider.cs
+++ b/src/iRLeagueApiCore.Server/Models/RequestLeagueProvider.cs
@@ -1,0 +1,18 @@
+﻿using iRLeagueDatabaseCore;
+
+namespace iRLeagueApiCore.Server.Models;
+
+public class RequestLeagueProvider : ILeagueProvider
+{
+    public long LeagueId { get; private set; } = 0;
+
+    public bool HasLeagueName => string.IsNullOrEmpty(LeagueName) == false;
+
+    public string LeagueName { get; private set; } = string.Empty;
+
+    public void SetLeague(long leagueId, string? leagueName = null)
+    {
+        LeagueId = leagueId;
+        LeagueName = leagueName ?? string.Empty;
+    }
+}

--- a/src/iRLeagueApiCore.Server/Startup.cs
+++ b/src/iRLeagueApiCore.Server/Startup.cs
@@ -4,6 +4,7 @@ using iRLeagueApiCore.Server.Authentication;
 using iRLeagueApiCore.Server.Extensions;
 using iRLeagueApiCore.Server.Filters;
 using iRLeagueApiCore.Server.Models;
+using iRLeagueDatabaseCore;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
@@ -127,9 +128,11 @@ public sealed class Startup
         services.AddDbContextFactory<UserDbContext, UserDbContextFactory>();
         services.AddScoped(x =>
             x.GetRequiredService<IDbContextFactory<UserDbContext>>().CreateDbContext());
-        services.AddDbContextFactory<LeagueDbContext, LeagueDbContextFactory>();
+        services.AddSingleton<LeagueDbContextFactory>();
+        services.AddScoped<RequestLeagueProvider>();
+        services.AddScoped<ILeagueProvider>(x => x.GetRequiredService<RequestLeagueProvider>());
         services.AddScoped(x =>
-            x.GetRequiredService<IDbContextFactory<LeagueDbContext>>().CreateDbContext());
+            x.GetRequiredService<LeagueDbContextFactory>().CreateDbContext(x.GetRequiredService<ILeagueProvider>()));
 
         services.AddIdentity<ApplicationUser, IdentityRole>()
             .AddEntityFrameworkStores<UserDbContext>()

--- a/src/iRLeagueApiCore.Server/Validation/Events/PostEventToScheduleRequestValidator.cs
+++ b/src/iRLeagueApiCore.Server/Validation/Events/PostEventToScheduleRequestValidator.cs
@@ -20,7 +20,6 @@ public sealed class PostEventToScheduleRequestValidator : AbstractValidator<Post
     public async Task<bool> EventExists(PostEventToScheduleRequest request, long scheduleId, CancellationToken cancellationToken)
     {
         return await dbContext.Schedules
-            .Where(x => x.LeagueId == request.LeagueId)
             .Where(x => x.ScheduleId == scheduleId)
             .AnyAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Validation/Results/PutResultConfigRequestValidator.cs
+++ b/src/iRLeagueApiCore.Server/Validation/Results/PutResultConfigRequestValidator.cs
@@ -23,7 +23,6 @@ public sealed class PutResultConfigRequestValidator : AbstractValidator<PutResul
             return true;
         }
         var exists = await dbContext.Scorings
-            .Where(x => x.LeagueId == request.LeagueId)
             .Where(x => x.ScoringId == scoringModel.Id)
             .Select(x => new { x.ResultConfigId })
             .FirstOrDefaultAsync(cancellationToken);

--- a/src/iRLeagueApiCore.Server/Validation/Reviews/PostReviewRequestValidator.cs
+++ b/src/iRLeagueApiCore.Server/Validation/Reviews/PostReviewRequestValidator.cs
@@ -14,16 +14,15 @@ public sealed class PostReviewRequestValidator : AbstractValidator<PostReviewToS
             .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage("No session selected")
-            .MustAsync((request, sessionId, cancellationToken) => SessionisValid(request.LeagueId, sessionId, cancellationToken))
+            .MustAsync((request, sessionId, cancellationToken) => SessionisValid(sessionId, cancellationToken))
             .WithMessage("Selected session does not exist");
         RuleFor(x => x.Model)
             .SetValidator(new PostReviewModelValidator(dbContext));
     }
 
-    private async Task<bool> SessionisValid(long leagueId, long sessionId, CancellationToken cancellationToken)
+    private async Task<bool> SessionisValid(long sessionId, CancellationToken cancellationToken)
     {
         return await dbContext.Sessions
-            .Where(x => x.LeagueId == leagueId)
             .Where(x => x.SessionId == sessionId)
             .AnyAsync(cancellationToken);
     }

--- a/src/iRLeagueApiCore.Server/Validation/Seasons/PostSeasonRequestValidator.cs
+++ b/src/iRLeagueApiCore.Server/Validation/Seasons/PostSeasonRequestValidator.cs
@@ -10,9 +10,6 @@ public sealed class PostSeasonRequestValidator : AbstractValidator<PostSeasonReq
     {
         this.dbContext = dbContext;
 
-        RuleFor(x => x.LeagueId)
-            .NotEmpty()
-            .WithMessage("League id required");
         RuleFor(x => x.Model)
             .SetValidator(modelValidator);
         RuleFor(x => x.Model.MainScoringId)
@@ -24,7 +21,6 @@ public sealed class PostSeasonRequestValidator : AbstractValidator<PostSeasonReq
     private async Task<bool> ScoringExists(PostSeasonRequest request, long? scoringId, CancellationToken cancellationToken)
     {
         return await dbContext.Scorings
-            .Where(x => x.LeagueId == request.LeagueId)
             .AnyAsync(x => x.ScoringId == scoringId);
     }
 }

--- a/src/iRLeagueApiCore.Server/Validation/Seasons/PutSeasonRequestValidator.cs
+++ b/src/iRLeagueApiCore.Server/Validation/Seasons/PutSeasonRequestValidator.cs
@@ -10,9 +10,6 @@ public sealed class PutSeasonRequestValidator : AbstractValidator<PutSeasonReque
     {
         this.dbContext = dbContext;
 
-        RuleFor(x => x.LeagueId)
-            .NotEmpty()
-            .WithMessage("League id required");
         RuleFor(x => x.SeasonId)
             .NotEmpty()
             .WithMessage("Season id required");
@@ -27,7 +24,6 @@ public sealed class PutSeasonRequestValidator : AbstractValidator<PutSeasonReque
     private async Task<bool> ScoringExists(PutSeasonRequest request, long? scoringId, CancellationToken cancellationToken)
     {
         return await dbContext.Scorings
-            .Where(x => x.LeagueId == request.LeagueId)
             .AnyAsync(x => x.ScoringId == scoringId);
     }
 }

--- a/src/iRLeagueApiCore.Server/iRLeagueApiCore.Server.csproj
+++ b/src/iRLeagueApiCore.Server/iRLeagueApiCore.Server.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.0.1" />
 	  <PackageReference Include="iRLeagueApiCore.Common" Version="0.6.4" CopyToOutputDirectory="lib/net6.0">
 	  </PackageReference>
-    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.4" />
+    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.2" />
 	<PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />

--- a/src/iRLeagueApiCore.Server/iRLeagueApiCore.Server.csproj
+++ b/src/iRLeagueApiCore.Server/iRLeagueApiCore.Server.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.0.1" />
 	  <PackageReference Include="iRLeagueApiCore.Common" Version="0.6.4" CopyToOutputDirectory="lib/net6.0">
 	  </PackageReference>
-    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.2" />
+    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.3" />
 	<PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />

--- a/src/iRLeagueApiCore.Services/iRLeagueApiCore.Services.csproj
+++ b/src/iRLeagueApiCore.Services/iRLeagueApiCore.Services.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="iRLeagueApiCore.Common" Version="0.6.4" />
-    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.2" />
+    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.3" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />

--- a/src/iRLeagueApiCore.Services/iRLeagueApiCore.Services.csproj
+++ b/src/iRLeagueApiCore.Services/iRLeagueApiCore.Services.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="iRLeagueApiCore.Common" Version="0.6.4" />
-    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.4" />
+    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />

--- a/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessMockHelper.cs
+++ b/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessMockHelper.cs
@@ -13,6 +13,8 @@ public sealed class DataAccessMockHelper
     private readonly Mock<ILeagueProvider> mockLeagueProvider = new();
     private long CurrentLeagueId { get; set; } = 0;
 
+    public ILeagueProvider LeagueProvider => mockLeagueProvider.Object;
+
     public DataAccessMockHelper()
     {
         mockLeagueProvider.Setup(x => x.LeagueId).Returns(() => CurrentLeagueId);
@@ -404,6 +406,11 @@ public sealed class DataAccessMockHelper
 
     public void SetCurrentLeague(LeagueEntity league)
     {
-        CurrentLeagueId = league.Id;
+        SetCurrentLeague(league.Id);
+    }
+
+    public void SetCurrentLeague(long leagueId)
+    {
+        CurrentLeagueId = leagueId;
     }
 }

--- a/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessMockHelper.cs
+++ b/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessMockHelper.cs
@@ -68,6 +68,8 @@ public sealed class DataAccessMockHelper
         var voteCategories = CreateVoteCategories(league);
         league.VoteCategories = voteCategories.ToList();
 
+        dbContext.Leagues.Add(CreateLeague());
+
         await dbContext.SaveChangesAsync();
     }
 

--- a/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessMockHelper.cs
+++ b/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessMockHelper.cs
@@ -1,6 +1,7 @@
 ﻿using AutoFixture.Dsl;
 using iRLeagueApiCore.Common.Enums;
 using iRLeagueApiCore.Services.ResultService.Extensions;
+using iRLeagueDatabaseCore;
 using iRLeagueDatabaseCore.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -9,13 +10,20 @@ namespace iRLeagueApiCore.Mocking.DataAccess;
 public sealed class DataAccessMockHelper
 {
     private readonly Fixture fixture = new();
+    private readonly Mock<ILeagueProvider> mockLeagueProvider = new();
+    private long CurrentLeagueId { get; set; } = 0;
+
+    public DataAccessMockHelper()
+    {
+        mockLeagueProvider.Setup(x => x.LeagueId).Returns(() => CurrentLeagueId);
+    }
 
     public LeagueDbContext CreateMockDbContext(string dbName)
     {
         var optionsBuilder = new DbContextOptionsBuilder<LeagueDbContext>();
         optionsBuilder.UseInMemoryDatabase(databaseName: dbName)
            .UseLazyLoadingProxies();
-        var dbContext = new LeagueDbContext(optionsBuilder.Options);
+        var dbContext = new LeagueDbContext(optionsBuilder.Options, mockLeagueProvider.Object);
 
         return dbContext;
     }
@@ -392,5 +400,10 @@ public sealed class DataAccessMockHelper
             .Without(x => x.AcceptedReviewVotes)
             .Without(x => x.CommentReviewVotes)
             .CreateMany();
+    }
+
+    public void SetCurrentLeague(LeagueEntity league)
+    {
+        CurrentLeagueId = league.Id;
     }
 }

--- a/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessTestsBase.cs
+++ b/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using iRLeagueDatabaseCore.Models;
+﻿using iRLeagueDatabaseCore;
+using iRLeagueDatabaseCore.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace iRLeagueApiCore.Mocking.DataAccess;
@@ -9,6 +10,8 @@ public abstract class DataAccessTestsBase : IAsyncLifetime
     protected readonly Fixture fixture;
     protected readonly DataAccessMockHelper accessMockHelper;
     protected readonly LeagueDbContext dbContext;
+    
+    protected ILeagueProvider LeagueProvider => accessMockHelper.LeagueProvider;
 
     public DataAccessTestsBase()
     {

--- a/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessTestsBase.cs
+++ b/test/iRLeagueApiCore.Mocking/iRLeagueApiCore.Mocking/DataAccess/DataAccessTestsBase.cs
@@ -1,4 +1,5 @@
 ﻿using iRLeagueDatabaseCore.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace iRLeagueApiCore.Mocking.DataAccess;
 
@@ -22,6 +23,7 @@ public abstract class DataAccessTestsBase : IAsyncLifetime
     {
         dbContext.Database.EnsureCreated();
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
     }
 
     public virtual async Task DisposeAsync()

--- a/test/iRLeagueApiCore.Services.Tests/ResultService/DataAccess/DataAccessMockHelperTests.cs
+++ b/test/iRLeagueApiCore.Services.Tests/ResultService/DataAccess/DataAccessMockHelperTests.cs
@@ -26,7 +26,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
 
         using (var dbContext = accessMockHelper.CreateMockDbContext(databaseName))
         {
-            dbContext.Leagues.Should().HaveCount(1);
+            dbContext.Leagues.Should().HaveCount(2);
         }
     }
 

--- a/test/iRLeagueApiCore.Services.Tests/ResultService/DataAccess/DataAccessMockHelperTests.cs
+++ b/test/iRLeagueApiCore.Services.Tests/ResultService/DataAccess/DataAccessMockHelperTests.cs
@@ -35,6 +35,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
     {
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
         var session = await dbContext.Sessions
             .Include(x => x.Event)
@@ -50,6 +51,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
     {
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
         var events = await dbContext.Events
             .Include(x => x.EventResult)
@@ -66,6 +68,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
     {
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
         var leagueMembers = await dbContext.LeagueMembers
             .Include(x => x.Team)
@@ -79,6 +82,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
     {
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
         var result = await dbContext.EventResults
             .Include(x => x.SessionResults)
@@ -92,6 +96,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
     {
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
         var sessions = await dbContext.Sessions
             .Include(x => x.IncidentReviews)
@@ -108,6 +113,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
     {
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         await accessMockHelper.PopulateBasicTestSet(dbContext);
+        accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
         var voteCategories = await dbContext.VoteCategories
             .ToListAsync();
@@ -125,6 +131,7 @@ public sealed class DataAccessMockHelperTests : IAsyncLifetime
         using (var dbContext = accessMockHelper.CreateMockDbContext(databaseName))
         {
             await accessMockHelper.PopulateBasicTestSet(dbContext);
+            accessMockHelper.SetCurrentLeague(await dbContext.Leagues.FirstAsync());
 
             var @event = await dbContext.Events
                 .Include(x => x.Schedule.Season.League)

--- a/test/iRLeagueApiCore.UnitTests/Fixtures/DbTestFixture.cs
+++ b/test/iRLeagueApiCore.UnitTests/Fixtures/DbTestFixture.cs
@@ -18,18 +18,6 @@ public sealed class DbTestFixture : DataAccessTestsBase
     {
     }
 
-    public static LeagueDbContext CreateStaticDbContext()
-    {
-        var optionsBuilder = new DbContextOptionsBuilder<LeagueDbContext>();
-
-        // use in memory database when no connection string present
-        //optionsBuilder.UseMySQL(connectionString);
-        optionsBuilder.UseInMemoryDatabase("TestDatabase");
-
-        var dbContext = new LeagueDbContext(optionsBuilder.Options);
-        return dbContext;
-    }
-
     public LeagueDbContext CreateDbContext()
     {
         var dbContext = accessMockHelper.CreateMockDbContext(databaseName);

--- a/test/iRLeagueApiCore.UnitTests/Server/Controllers/AdminControllerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Controllers/AdminControllerTests.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace iRLeagueApiCore.UnitTests.Server.Controllers;
 
-public sealed class AdminDbTestFixture
+public sealed class AdminControllerTests
 {
     readonly ILogger<AdminController> _mockLogger = new Mock<ILogger<AdminController>>().Object;
     ApplicationUser MockUser { get; }
@@ -23,7 +23,7 @@ public sealed class AdminDbTestFixture
     const string TestLeagueName = "TestLeague";
     string TestLeagueRoleName = LeagueRoles.GetLeagueRoleName(TestLeagueName, TestRoleName) ?? string.Empty;
 
-    public AdminDbTestFixture()
+    public AdminControllerTests()
     {
         var userMock = new Mock<ApplicationUser>();
         userMock.SetupAllProperties();

--- a/test/iRLeagueApiCore.UnitTests/Server/Controllers/LeagueControllerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Controllers/LeagueControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using iRLeagueApiCore.Common.Models;
+using iRLeagueApiCore.Mocking.DataAccess;
 using iRLeagueApiCore.Server.Controllers;
 using iRLeagueApiCore.Server.Handlers.Leagues;
 using iRLeagueApiCore.UnitTests.Fixtures;
@@ -10,21 +11,17 @@ using Xunit.Abstractions;
 
 namespace iRLeagueApiCore.UnitTests.Server.Controllers;
 
-public sealed class LeagueDbTestFixture : IClassFixture<DbTestFixture>
+public sealed class LeagueControllerTests : DataAccessTestsBase
 {
-    DbTestFixture Fixture { get; }
-    ITestOutputHelper Output { get; }
     ILogger<LeaguesController> MockLogger { get; }
 
     private const string testLeagueName = "TestLeague";
     private const string testFullName = "Full Name";
     private const long testLeagueId = 1;
 
-    public LeagueDbTestFixture(DbTestFixture fixture, ITestOutputHelper output)
+    public LeagueControllerTests()
     {
-        Fixture = fixture;
         MockLogger = new Mock<ILogger<LeaguesController>>().Object;
-        Output = output;
     }
 
     private LeaguesController CreateController(IMediator mediator)

--- a/test/iRLeagueApiCore.UnitTests/Server/Controllers/ScheduleControllerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Controllers/ScheduleControllerTests.cs
@@ -48,11 +48,10 @@ public sealed class ScheduleControllerTests
     public async Task GetSchedulesValid()
     {
         var expectedResult = new ScheduleModel[] { DefaultGetModel() };
-        var mediator = MockHelpers.TestMediator<GetSchedulesRequest, IEnumerable<ScheduleModel>>(x =>
-            x.LeagueId == testLeagueId, expectedResult);
+        var mediator = MockHelpers.TestMediator<GetSchedulesRequest, IEnumerable<ScheduleModel>>(result: expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SchedulesController(logger, mediator));
 
-        var result = await controller.GetAll(testLeagueName, testLeagueId);
+        var result = await controller.GetAll(testLeagueName);
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -64,10 +63,10 @@ public sealed class ScheduleControllerTests
     {
         var expectedResult = DefaultGetModel();
         var mediator = MockHelpers.TestMediator<GetScheduleRequest, ScheduleModel>(x =>
-            x.LeagueId == testLeagueId && x.ScheduleId == testScheduleId, expectedResult);
+            x.ScheduleId == testScheduleId, expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SchedulesController(logger, mediator));
 
-        var result = await controller.Get(testLeagueName, testLeagueId, testScheduleId);
+        var result = await controller.Get(testLeagueName, testScheduleId);
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -78,11 +77,10 @@ public sealed class ScheduleControllerTests
     public async Task PostScheduleValid()
     {
         var expectedResult = DefaultGetModel();
-        var mediator = MockHelpers.TestMediator<PostScheduleRequest, ScheduleModel>(x =>
-            x.LeagueId == testLeagueId, expectedResult);
+        var mediator = MockHelpers.TestMediator<PostScheduleRequest, ScheduleModel>(result: expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SchedulesController(logger, mediator));
 
-        var result = await controller.Post(testLeagueName, testSeasonÍd, testLeagueId, DefaultPostModel());
+        var result = await controller.Post(testLeagueName, testSeasonÍd, DefaultPostModel());
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
         Assert.Equal(expectedResult, createdResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -94,10 +92,10 @@ public sealed class ScheduleControllerTests
     {
         var expectedResult = DefaultGetModel();
         var mediator = MockHelpers.TestMediator<PutScheduleRequest, ScheduleModel>(x =>
-            x.LeagueId == testLeagueId && x.ScheduleId == testScheduleId, expectedResult);
+            x.ScheduleId == testScheduleId, expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SchedulesController(logger, mediator));
 
-        var result = await controller.Put(testLeagueName, testLeagueId, testScheduleId, DefaultPutModel());
+        var result = await controller.Put(testLeagueName, testScheduleId, DefaultPutModel());
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -108,10 +106,10 @@ public sealed class ScheduleControllerTests
     public async Task DeleteScheduleValid()
     {
         var mediator = MockHelpers.TestMediator<DeleteScheduleRequest, Unit>(x =>
-            x.LeagueId == testLeagueId && x.ScheduleId == testScheduleId);
+            x.ScheduleId == testScheduleId);
         var controller = AddContexts.AddMemberControllerContext(new SchedulesController(logger, mediator));
 
-        var result = await controller.Delete(testLeagueName, testLeagueId, testScheduleId);
+        var result = await controller.Delete(testLeagueName, testScheduleId);
         Assert.IsType<NoContentResult>(result);
         var mediatorMock = Mock.Get(mediator);
         mediatorMock.Verify(x => x.Send(It.IsAny<DeleteScheduleRequest>(), default));

--- a/test/iRLeagueApiCore.UnitTests/Server/Controllers/ScheduleControllerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Controllers/ScheduleControllerTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace iRLeagueApiCore.UnitTests.Server.Controllers;
 
-public sealed class ScheduleDbTestFixture
+public sealed class ScheduleControllerTests
 {
     private readonly ILogger<SchedulesController> logger;
 
@@ -19,7 +19,7 @@ public sealed class ScheduleDbTestFixture
     const long testScheduleId = 1;
     const string testScheduleName = "Schedule 1";
 
-    public ScheduleDbTestFixture()
+    public ScheduleControllerTests()
     {
         logger = Mock.Of<ILogger<SchedulesController>>();
     }

--- a/test/iRLeagueApiCore.UnitTests/Server/Controllers/ScoringControllerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Controllers/ScoringControllerTests.cs
@@ -11,16 +11,15 @@ using Microsoft.Extensions.Logging;
 
 namespace iRLeagueApiCore.UnitTests.Server.Controllers;
 
-public sealed class ScoringDbTestFixture
+public sealed class ScoringControllerTests
 {
     private readonly ILogger<ScoringsController> logger;
 
     const string testLeagueName = "TestLeague";
     const long testLeagueId = 1;
-    const long testSeasonId = 1;
     const long testScoringId = 1;
 
-    public ScoringDbTestFixture()
+    public ScoringControllerTests()
     {
         logger = Mock.Of<ILogger<ScoringsController>>();
     }
@@ -34,35 +33,19 @@ public sealed class ScoringDbTestFixture
         };
     }
 
-    private static PostScoringModel DefaultPostModel()
-    {
-        return new PostScoringModel();
-    }
-
     private static PutScoringModel DefaultPutModel()
     {
         return new PutScoringModel();
-    }
-
-    private static ResourceNotFoundException NotFound()
-    {
-        return new ResourceNotFoundException();
-    }
-
-    private static ValidationException ValidationFailed()
-    {
-        return new ValidationException("Test validation failed");
     }
 
     [Fact]
     public async Task GetScoringsValid()
     {
         var expectedResult = new ScoringModel[] { DefaultGetModel() };
-        var mediator = MockHelpers.TestMediator<GetScoringsRequest, IEnumerable<ScoringModel>>(x =>
-            x.LeagueId == testLeagueId, expectedResult);
+        var mediator = MockHelpers.TestMediator<GetScoringsRequest, IEnumerable<ScoringModel>>(result: expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
 
-        var result = await controller.Get(testLeagueName, testLeagueId);
+        var result = await controller.Get(testLeagueName);
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -70,34 +53,14 @@ public sealed class ScoringDbTestFixture
     }
 
     [Fact]
-    public async Task GetScoringsNotFound()
-    {
-        var mediator = MockHelpers.TestMediator<GetScoringsRequest, IEnumerable<ScoringModel>>(throws: NotFound());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Get(testLeagueName, testLeagueId);
-        Assert.IsType<NotFoundResult>(result.Result);
-    }
-
-    [Fact]
-    public async Task GetScoringsValidationFailed()
-    {
-        var mediator = MockHelpers.TestMediator<GetScoringsRequest, IEnumerable<ScoringModel>>(throws: ValidationFailed());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Get(testLeagueName, testLeagueId);
-        Assert.IsType<BadRequestObjectResult>(result.Result);
-    }
-
-    [Fact]
     public async Task GetScoringValid()
     {
         var expectedResult = DefaultGetModel();
         var mediator = MockHelpers.TestMediator<GetScoringRequest, ScoringModel>(x =>
-            x.LeagueId == testLeagueId && x.ScoringId == testScoringId, expectedResult);
+            x.ScoringId == testScoringId, expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
 
-        var result = await controller.Get(testLeagueName, testLeagueId, testScoringId);
+        var result = await controller.Get(testLeagueName, testScoringId);
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -105,34 +68,14 @@ public sealed class ScoringDbTestFixture
     }
 
     [Fact]
-    public async Task GetScoringNotFound()
-    {
-        var mediator = MockHelpers.TestMediator<GetScoringRequest, ScoringModel>(throws: NotFound());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Get(testLeagueName, testLeagueId, testScoringId);
-        Assert.IsType<NotFoundResult>(result.Result);
-    }
-
-    [Fact]
-    public async Task GetScoringValidationFailed()
-    {
-        var mediator = MockHelpers.TestMediator<GetScoringRequest, ScoringModel>(throws: ValidationFailed());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Get(testLeagueName, testLeagueId, testScoringId);
-        Assert.IsType<BadRequestObjectResult>(result.Result);
-    }
-
-    [Fact]
     public async Task PutScoringValid()
     {
         var expectedResult = DefaultGetModel();
         var mediator = MockHelpers.TestMediator<PutScoringRequest, ScoringModel>(x =>
-            x.LeagueId == testLeagueId && x.ScoringId == testScoringId, expectedResult);
+            x.ScoringId == testScoringId, expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
 
-        var result = await controller.Put(testLeagueName, testLeagueId, testScoringId, DefaultPutModel());
+        var result = await controller.Put(testLeagueName, testScoringId, DefaultPutModel());
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -140,55 +83,15 @@ public sealed class ScoringDbTestFixture
     }
 
     [Fact]
-    public async Task PutScoringNotFound()
-    {
-        var mediator = MockHelpers.TestMediator<PutScoringRequest, ScoringModel>(throws: NotFound());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Put(testLeagueName, testLeagueId, testScoringId, DefaultPutModel());
-        Assert.IsType<NotFoundResult>(result.Result);
-    }
-
-    [Fact]
-    public async Task PutScoringValidationFailed()
-    {
-        var mediator = MockHelpers.TestMediator<PutScoringRequest, ScoringModel>(throws: ValidationFailed());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Put(testLeagueName, testLeagueId, testScoringId, DefaultPutModel());
-        Assert.IsType<BadRequestObjectResult>(result.Result);
-    }
-
-    [Fact]
     public async Task DeleteScoringValid()
     {
         var mediator = MockHelpers.TestMediator<DeleteScoringRequest, Unit>(x =>
-            x.LeagueId == testLeagueId && x.ScoringId == testScoringId);
+            x.ScoringId == testScoringId);
         var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
 
-        var result = await controller.Delete(testLeagueName, testLeagueId, testScoringId);
+        var result = await controller.Delete(testLeagueName, testScoringId);
         Assert.IsType<NoContentResult>(result);
         var mediatorMock = Mock.Get(mediator);
         mediatorMock.Verify(x => x.Send(It.IsAny<DeleteScoringRequest>(), default));
-    }
-
-    [Fact]
-    public async Task DeleteScoringNotFound()
-    {
-        var mediator = MockHelpers.TestMediator<DeleteScoringRequest, Unit>(throws: NotFound());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Delete(testLeagueName, testLeagueId, testScoringId);
-        Assert.IsType<NotFoundResult>(result);
-    }
-
-    [Fact]
-    public async Task DeleteScoringValidationFailed()
-    {
-        var mediator = MockHelpers.TestMediator<DeleteScoringRequest, Unit>(throws: ValidationFailed());
-        var controller = AddContexts.AddMemberControllerContext(new ScoringsController(logger, mediator));
-
-        var result = await controller.Delete(testLeagueName, testLeagueId, testScoringId);
-        Assert.IsType<BadRequestObjectResult>(result);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Controllers/SeasonControllerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Controllers/SeasonControllerTests.cs
@@ -59,11 +59,10 @@ public sealed class SeasonDbTestFixture
     public async Task GetSeasonsValid()
     {
         var expectedResult = new SeasonModel[] { DefaultGetModel() };
-        var mediator = MockHelpers.TestMediator<GetSeasonsRequest, IEnumerable<SeasonModel>>(x =>
-            x.LeagueId == testLeagueId, expectedResult);
+        var mediator = MockHelpers.TestMediator<GetSeasonsRequest, IEnumerable<SeasonModel>>(result: expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SeasonsController(logger, mediator));
 
-        var result = await controller.GetAll(testLeagueName, testLeagueId);
+        var result = await controller.GetAll(testLeagueName);
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -75,10 +74,10 @@ public sealed class SeasonDbTestFixture
     {
         var expectedResult = DefaultGetModel();
         var mediator = MockHelpers.TestMediator<GetSeasonRequest, SeasonModel>(x =>
-            x.LeagueId == testLeagueId && x.SeasonId == testSeasonId, expectedResult);
+            x.SeasonId == testSeasonId, expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SeasonsController(logger, mediator));
 
-        var result = await controller.Get(testLeagueName, testLeagueId, testSeasonId);
+        var result = await controller.Get(testLeagueName, testSeasonId);
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -89,11 +88,10 @@ public sealed class SeasonDbTestFixture
     public async Task PostSeasonValid()
     {
         var expectedResult = DefaultGetModel();
-        var mediator = MockHelpers.TestMediator<PostSeasonRequest, SeasonModel>(x =>
-            x.LeagueId == testLeagueId, expectedResult);
+        var mediator = MockHelpers.TestMediator<PostSeasonRequest, SeasonModel>(result: expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SeasonsController(logger, mediator));
 
-        var result = await controller.Post(testLeagueName, testLeagueId, DefaultPostModel());
+        var result = await controller.Post(testLeagueName, DefaultPostModel());
         var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
         Assert.Equal(expectedResult, createdResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -105,10 +103,10 @@ public sealed class SeasonDbTestFixture
     {
         var expectedResult = DefaultGetModel();
         var mediator = MockHelpers.TestMediator<PutSeasonRequest, SeasonModel>(x =>
-            x.LeagueId == testLeagueId && x.SeasonId == testSeasonId, expectedResult);
+            x.SeasonId == testSeasonId, expectedResult);
         var controller = AddContexts.AddMemberControllerContext(new SeasonsController(logger, mediator));
 
-        var result = await controller.Put(testLeagueName, testLeagueId, testSeasonId, DefaultPutModel());
+        var result = await controller.Put(testLeagueName, testSeasonId, DefaultPutModel());
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal(expectedResult, okResult.Value);
         var mediatorMock = Mock.Get(mediator);
@@ -119,10 +117,10 @@ public sealed class SeasonDbTestFixture
     public async Task DeleteSeasonValid()
     {
         var mediator = MockHelpers.TestMediator<DeleteSeasonRequest, Unit>(x =>
-            x.LeagueId == testLeagueId && x.SeasonId == testSeasonId);
+            x.SeasonId == testSeasonId);
         var controller = AddContexts.AddMemberControllerContext(new SeasonsController(logger, mediator));
 
-        var result = await controller.Delete(testLeagueName, testLeagueId, testSeasonId);
+        var result = await controller.Delete(testLeagueName, testSeasonId);
         Assert.IsType<NoContentResult>(result);
         var mediatorMock = Mock.Get(mediator);
         mediatorMock.Verify(x => x.Send(It.IsAny<DeleteSeasonRequest>(), default));

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/DeleteChampSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/DeleteChampSeasonHandlerTests.cs
@@ -11,17 +11,17 @@ public sealed class DeleteChampSeasonHandlerTests :
     protected override DeleteChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, 
         IValidator<DeleteChampSeasonRequest> validator)
     {
-        return new DeleteChampSeasonHandler(logger, dbContext, new[] { validator });
+        return new DeleteChampSeasonHandler(logger, dbContext, new[] { validator }, LeagueProvider);
     }
 
     protected override DeleteChampSeasonRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestChampSeasonId);
+        return DefaultRequest(TestChampSeasonId);
     }
 
-    private DeleteChampSeasonRequest DefaultRequest(long leagueId, long champSeasonId)
+    private DeleteChampSeasonRequest DefaultRequest(long champSeasonId)
     {
-        return new DeleteChampSeasonRequest(leagueId, champSeasonId);
+        return new DeleteChampSeasonRequest(champSeasonId);
     }
 
     protected override void DefaultAssertions(DeleteChampSeasonRequest request, Unit result, LeagueDbContext dbContext)

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/DeleteChampSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/DeleteChampSeasonHandlerTests.cs
@@ -11,7 +11,7 @@ public sealed class DeleteChampSeasonHandlerTests :
     protected override DeleteChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, 
         IValidator<DeleteChampSeasonRequest> validator)
     {
-        return new DeleteChampSeasonHandler(logger, dbContext, new[] { validator }, LeagueProvider);
+        return new DeleteChampSeasonHandler(logger, dbContext, new[] { validator });
     }
 
     protected override DeleteChampSeasonRequest DefaultRequest()

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PostChampSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PostChampSeasonHandlerTests.cs
@@ -10,17 +10,17 @@ public sealed class PostChampSeasonHandlerTests : ChampionshipHandlersTestsBase<
 {
     protected override PostChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PostChampSeasonRequest> validator)
     {
-        return new PostChampSeasonHandler(logger, dbContext, new[] { validator });
+        return new PostChampSeasonHandler(logger, dbContext, new[] { validator }, LeagueProvider);
     }
 
     protected override PostChampSeasonRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestChampionshipId, TestSeasonId);
+        return DefaultRequest(TestChampionshipId, TestSeasonId);
     }
 
-    private PostChampSeasonRequest DefaultRequest(long leagueId, long championshipId, long seasonId)
+    private PostChampSeasonRequest DefaultRequest(long championshipId, long seasonId)
     {
-        return new(leagueId, championshipId, seasonId, DefaultUser(), new());
+        return new(championshipId, seasonId, DefaultUser(), new());
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public sealed class PostChampSeasonHandlerTests : ChampionshipHandlersTestsBase<
     [Fact]
     public async Task Handle_ShouldCopySettings_WhenPreviousSeasonExists()
     {
-        var request = DefaultRequest(TestLeagueId, TestChampionshipId, (await dbContext.Seasons.Skip(1).FirstAsync()).SeasonId);
+        var request = DefaultRequest(TestChampionshipId, (await dbContext.Seasons.Skip(1).FirstAsync()).SeasonId);
         var champSeasonQuery = dbContext.ChampSeasons
             .Include(x => x.Championship)
             .Include(x => x.ResultConfigurations)
@@ -75,7 +75,7 @@ public sealed class PostChampSeasonHandlerTests : ChampionshipHandlersTestsBase<
         champSeason.IsActive = false;
         await dbContext.SaveChangesAsync();
 
-        var request = DefaultRequest(TestLeagueId, champSeason.ChampionshipId, champSeason.SeasonId);
+        var request = DefaultRequest(champSeason.ChampionshipId, champSeason.SeasonId);
         await HandleSpecialAsync(request, async (request, model, context) =>
         {
             var test = await context.ChampSeasons.FirstAsync();

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PostChampSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PostChampSeasonHandlerTests.cs
@@ -10,7 +10,7 @@ public sealed class PostChampSeasonHandlerTests : ChampionshipHandlersTestsBase<
 {
     protected override PostChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PostChampSeasonRequest> validator)
     {
-        return new PostChampSeasonHandler(logger, dbContext, new[] { validator }, LeagueProvider);
+        return new PostChampSeasonHandler(logger, dbContext, new[] { validator });
     }
 
     protected override PostChampSeasonRequest DefaultRequest()

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PutChampSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PutChampSeasonHandlerTests.cs
@@ -8,7 +8,7 @@ public sealed class PutChampSeasonHandlerTests : ChampionshipHandlersTestsBase<P
 {
     protected override PutChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PutChampSeasonRequest> validator)
     {
-        return new(logger, dbContext, new[] { validator });
+        return new(logger, dbContext, new[] { validator }, LeagueProvider);
     }
 
     protected override PutChampSeasonRequest DefaultRequest()

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PutChampSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Championships/PutChampSeasonHandlerTests.cs
@@ -8,7 +8,7 @@ public sealed class PutChampSeasonHandlerTests : ChampionshipHandlersTestsBase<P
 {
     protected override PutChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PutChampSeasonRequest> validator)
     {
-        return new(logger, dbContext, new[] { validator }, LeagueProvider);
+        return new(logger, dbContext, new[] { validator });
     }
 
     protected override PutChampSeasonRequest DefaultRequest()

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/HandlersTestsBase.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/HandlersTestsBase.cs
@@ -11,6 +11,7 @@ using iRLeagueApiCore.UnitTests.Fixtures;
 using iRLeagueDatabaseCore.Models;
 using MediatR;
 using Microsoft.AspNetCore.Identity.Test;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 
@@ -24,22 +25,22 @@ public abstract class HandlersTestsBase<THandler, TRequest, TResult> : DataAcces
 
     protected const object? defaultId = null;
 
-    protected long TestLeagueId => dbContext.Leagues.First().Id;
+    protected long TestLeagueId => dbContext.Leagues.IgnoreQueryFilters().First().Id;
     protected const string testLeagueName = "TestLeague";
-    protected long TestSeasonId => dbContext.Seasons.First().SeasonId;
-    protected long TestScoringId => dbContext.Scorings.First().ScoringId;
-    protected long TestScheduleId => dbContext.Schedules.First().ScheduleId;
-    protected long TestEventId => dbContext.Events.First().EventId;
-    protected long TestSessionId => dbContext.Sessions.First().SessionId;
-    protected long TestResultId => dbContext.ScoredEventResults.First().ResultId;
-    protected long TestPointRuleId => dbContext.PointRules.First().PointRuleId;
-    protected long TestResultConfigId => dbContext.ResultConfigurations.First().ResultConfigId;
-    protected long TestReviewId => dbContext.IncidentReviews.First().ReviewId;
-    protected long TestMemberId => dbContext.Members.First().Id;
-    protected long TestMemberId2 => dbContext.Members.Skip(1).First().Id;
-    protected long TestCommentId => dbContext.ReviewComments.First().CommentId;
-    protected long TestReviewVoteId => dbContext.AcceptedReviewVotes.First().ReviewVoteId;
-    protected long TestVoteCategory => dbContext.VoteCategories.First().CatId;
+    protected long TestSeasonId => dbContext.Seasons.IgnoreQueryFilters().First().SeasonId;
+    protected long TestScoringId => dbContext.Scorings.IgnoreQueryFilters().First().ScoringId;
+    protected long TestScheduleId => dbContext.Schedules.IgnoreQueryFilters().First().ScheduleId;
+    protected long TestEventId => dbContext.Events.IgnoreQueryFilters().First().EventId;
+    protected long TestSessionId => dbContext.Sessions.IgnoreQueryFilters().First().SessionId;
+    protected long TestResultId => dbContext.ScoredEventResults.IgnoreQueryFilters().First().ResultId;
+    protected long TestPointRuleId => dbContext.PointRules.IgnoreQueryFilters().First().PointRuleId;
+    protected long TestResultConfigId => dbContext.ResultConfigurations.IgnoreQueryFilters().First().ResultConfigId;
+    protected long TestReviewId => dbContext.IncidentReviews.IgnoreQueryFilters().First().ReviewId;
+    protected long TestMemberId => dbContext.Members.IgnoreQueryFilters().First().Id;
+    protected long TestMemberId2 => dbContext.Members.Skip(1).IgnoreQueryFilters().First().Id;
+    protected long TestCommentId => dbContext.ReviewComments.IgnoreQueryFilters().First().CommentId;
+    protected long TestReviewVoteId => dbContext.AcceptedReviewVotes.IgnoreQueryFilters().First().ReviewVoteId;
+    protected long TestVoteCategory => dbContext.VoteCategories.IgnoreQueryFilters().First().CatId;
     protected const string testUserName = "TestUser";
     protected const string testUserId = "a0031cbe-a28b-48ac-a6db-cdca446a8162";
     protected static IEnumerable<string> testLeagueRoles = new string[] { LeagueRoles.Member };

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/DeleteResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/DeleteResultConfigHandlerTests.cs
@@ -13,17 +13,17 @@ public sealed class DeleteResultConfigHandlerTests : ResultHandlersTestsBase<Del
 
     protected override DeleteResultConfigHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<DeleteResultConfigRequest> validator)
     {
-        return new DeleteResultConfigHandler(logger, dbContext, new IValidator<DeleteResultConfigRequest>[] { validator });
+        return new DeleteResultConfigHandler(logger, dbContext, new IValidator<DeleteResultConfigRequest>[] { validator }, accessMockHelper.LeagueProvider);
     }
 
-    private DeleteResultConfigRequest DefaultRequest(long leagueId, long resultConfigId)
+    private DeleteResultConfigRequest DefaultRequest(long resultConfigId)
     {
-        return new DeleteResultConfigRequest(leagueId, resultConfigId);
+        return new DeleteResultConfigRequest(resultConfigId);
     }
 
     protected override DeleteResultConfigRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestResultConfigId);
+        return DefaultRequest(TestResultConfigId);
     }
 
     protected override void DefaultAssertions(DeleteResultConfigRequest request, MediatR.Unit result, LeagueDbContext dbContext)
@@ -50,7 +50,8 @@ public sealed class DeleteResultConfigHandlerTests : ResultHandlersTestsBase<Del
     {
         leagueId ??= TestLeagueId;
         resultId ??= TestResultId;
-        var request = DefaultRequest(leagueId.Value, resultId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(resultId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/DeleteResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/DeleteResultConfigHandlerTests.cs
@@ -13,7 +13,7 @@ public sealed class DeleteResultConfigHandlerTests : ResultHandlersTestsBase<Del
 
     protected override DeleteResultConfigHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<DeleteResultConfigRequest> validator)
     {
-        return new DeleteResultConfigHandler(logger, dbContext, new IValidator<DeleteResultConfigRequest>[] { validator }, accessMockHelper.LeagueProvider);
+        return new DeleteResultConfigHandler(logger, dbContext, new IValidator<DeleteResultConfigRequest>[] { validator });
     }
 
     private DeleteResultConfigRequest DefaultRequest(long resultConfigId)

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigHandlerTests.cs
@@ -18,17 +18,17 @@ public sealed class GetResultConfigHandlerTests : ResultHandlersTestsBase<GetRes
     protected override GetResultConfigHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<GetResultConfigRequest>? validator = null)
     {
         return new GetResultConfigHandler(logger, dbContext,
-            new IValidator<GetResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<GetResultConfigRequest>() });
+            new IValidator<GetResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<GetResultConfigRequest>() }, accessMockHelper.LeagueProvider);
     }
 
-    private GetResultConfigRequest DefaultRequest(long leagueId, long resultConfigId)
+    private GetResultConfigRequest DefaultRequest(long resultConfigId)
     {
-        return new GetResultConfigRequest(leagueId, resultConfigId);
+        return new GetResultConfigRequest(resultConfigId);
     }
 
     protected override GetResultConfigRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestResultConfigId);
+        return DefaultRequest(TestResultConfigId);
     }
 
     protected override void DefaultAssertions(GetResultConfigRequest request, ResultConfigModel result, LeagueDbContext dbContext)
@@ -36,7 +36,6 @@ public sealed class GetResultConfigHandlerTests : ResultHandlersTestsBase<GetRes
         var resultConfigEntity = dbContext.ResultConfigurations
             .FirstOrDefault(x => x.ResultConfigId == request.ResultConfigId);
         resultConfigEntity.Should().NotBeNull();
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ResultConfigId.Should().Be(request.ResultConfigId);
         result.Name.Should().Be(resultConfigEntity!.Name);
         result.DisplayName.Should().Be(resultConfigEntity.DisplayName);
@@ -59,7 +58,8 @@ public sealed class GetResultConfigHandlerTests : ResultHandlersTestsBase<GetRes
     {
         leagueId ??= TestLeagueId;
         resultConfigId ??= TestResultConfigId;
-        var request = DefaultRequest(leagueId!.Value, resultConfigId!.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(resultConfigId!.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigHandlerTests.cs
@@ -18,7 +18,7 @@ public sealed class GetResultConfigHandlerTests : ResultHandlersTestsBase<GetRes
     protected override GetResultConfigHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<GetResultConfigRequest>? validator = null)
     {
         return new GetResultConfigHandler(logger, dbContext,
-            new IValidator<GetResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<GetResultConfigRequest>() }, accessMockHelper.LeagueProvider);
+            new IValidator<GetResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<GetResultConfigRequest>() });
     }
 
     private GetResultConfigRequest DefaultRequest(long resultConfigId)

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigsFromSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigsFromSeasonHandlerTests.cs
@@ -10,12 +10,12 @@ public sealed class GetResultConfigsFromSeasonHandlerTests : ResultHandlersTests
 {
     protected override GetResultConfigsFromSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<GetResultConfigsFromSeasonRequest> validator)
     {
-        return new(logger, dbContext, new[] { validator });
+        return new(logger, dbContext, new[] { validator }, accessMockHelper.LeagueProvider);
     }
 
-    protected override GetResultConfigsFromSeasonRequest DefaultRequest() => DefaultRequest(TestLeagueId, TestSeasonId);
+    protected override GetResultConfigsFromSeasonRequest DefaultRequest() => DefaultRequest(TestSeasonId);
 
-    private GetResultConfigsFromSeasonRequest DefaultRequest(long leagueId, long seasonId) => new(leagueId, seasonId);
+    private GetResultConfigsFromSeasonRequest DefaultRequest(long seasonId) => new(seasonId);
 
     protected override void DefaultAssertions(GetResultConfigsFromSeasonRequest request, IEnumerable<ResultConfigModel> result, LeagueDbContext dbContext)
     {

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigsFromSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultConfigsFromSeasonHandlerTests.cs
@@ -10,7 +10,7 @@ public sealed class GetResultConfigsFromSeasonHandlerTests : ResultHandlersTests
 {
     protected override GetResultConfigsFromSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<GetResultConfigsFromSeasonRequest> validator)
     {
-        return new(logger, dbContext, new[] { validator }, accessMockHelper.LeagueProvider);
+        return new(logger, dbContext, new[] { validator });
     }
 
     protected override GetResultConfigsFromSeasonRequest DefaultRequest() => DefaultRequest(TestSeasonId);

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultHandlerTests.cs
@@ -20,19 +20,18 @@ public sealed class GetResultHandlerTests : ResultHandlersTestsBase<GetResultHan
 
     protected override GetResultRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestResultId);
+        return DefaultRequest(TestResultId);
     }
 
-    private GetResultRequest DefaultRequest(long leagueId, long resultId)
+    private GetResultRequest DefaultRequest(long resultId)
     {
-        return new GetResultRequest(leagueId, resultId);
+        return new GetResultRequest(resultId);
     }
 
     protected override void DefaultAssertions(GetResultRequest request, EventResultModel result, LeagueDbContext dbContext)
     {
         base.DefaultAssertions(request, result, dbContext);
         var actualResult = dbContext.ScoredEventResults
-            .Where(x => x.LeagueId == request.LeagueId)
             .Where(x => x.ResultId == request.ResultId)
             .Include(x => x.ScoredSessionResults)
                 .ThenInclude(x => x.ScoredResultRows)
@@ -65,7 +64,8 @@ public sealed class GetResultHandlerTests : ResultHandlersTestsBase<GetResultHan
     {
         leagueId ??= TestLeagueId;
         resultId ??= TestResultId;
-        var request = DefaultRequest(leagueId.Value, resultId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(resultId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultsFromSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/GetResultsFromSeasonHandlerTests.cs
@@ -19,19 +19,18 @@ public sealed class GetResultsFromSeasonHandlerTests : ResultHandlersTestsBase<G
 
     protected override GetResultsFromSeasonRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestSeasonId);
+        return DefaultRequest(TestSeasonId);
     }
 
-    private GetResultsFromSeasonRequest DefaultRequest(long leagueId, long seasonId)
+    private GetResultsFromSeasonRequest DefaultRequest(long seasonId)
     {
-        return new GetResultsFromSeasonRequest(leagueId, seasonId);
+        return new GetResultsFromSeasonRequest(seasonId);
     }
 
     protected override void DefaultAssertions(GetResultsFromSeasonRequest request, IEnumerable<SeasonEventResultModel> result, LeagueDbContext dbContext)
     {
         base.DefaultAssertions(request, result, dbContext);
         var seasonResults = dbContext.ScoredEventResults
-            .Where(x => x.LeagueId == request.LeagueId)
             .Where(x => x.Event.Schedule.SeasonId == request.SeasonId)
             .GroupBy(x => x.EventId);
         Assert.Equal(seasonResults.Count(), result.Count());
@@ -58,7 +57,8 @@ public sealed class GetResultsFromSeasonHandlerTests : ResultHandlersTestsBase<G
     {
         leagueId ??= TestLeagueId;
         seasonId ??= TestSeasonId;
-        var request = DefaultRequest(leagueId.Value, seasonId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(seasonId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PostResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PostResultConfigHandlerTests.cs
@@ -15,7 +15,7 @@ public sealed class PostResultConfigHandlerTests : ResultHandlersTestsBase<PostR
 
     protected override PostResultConfigToChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PostResultConfigToChampSeasonRequest> validator)
     {
-        return new PostResultConfigToChampSeasonHandler(logger, dbContext, new IValidator<PostResultConfigToChampSeasonRequest>[] { validator });
+        return new PostResultConfigToChampSeasonHandler(logger, dbContext, new IValidator<PostResultConfigToChampSeasonRequest>[] { validator }, accessMockHelper.LeagueProvider);
     }
 
     protected override PostResultConfigToChampSeasonRequest DefaultRequest()
@@ -26,13 +26,12 @@ public sealed class PostResultConfigHandlerTests : ResultHandlersTestsBase<PostR
             DisplayName = "TestResultConfig DisplayName",
             ResultsPerTeam = 10,
         };
-        return new PostResultConfigToChampSeasonRequest(TestLeagueId, TestChampSeasonId, DefaultUser(), postResultConfig);
+        return new PostResultConfigToChampSeasonRequest(TestChampSeasonId, DefaultUser(), postResultConfig);
     }
 
     protected override void DefaultAssertions(PostResultConfigToChampSeasonRequest request, ResultConfigModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ResultConfigId.Should().NotBe(0);
         result.Name.Should().Be(expected.Name);
         result.DisplayName.Should().Be(expected.DisplayName);

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PostResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PostResultConfigHandlerTests.cs
@@ -15,7 +15,7 @@ public sealed class PostResultConfigHandlerTests : ResultHandlersTestsBase<PostR
 
     protected override PostResultConfigToChampSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PostResultConfigToChampSeasonRequest> validator)
     {
-        return new PostResultConfigToChampSeasonHandler(logger, dbContext, new IValidator<PostResultConfigToChampSeasonRequest>[] { validator }, accessMockHelper.LeagueProvider);
+        return new PostResultConfigToChampSeasonHandler(logger, dbContext, new IValidator<PostResultConfigToChampSeasonRequest>[] { validator });
     }
 
     protected override PostResultConfigToChampSeasonRequest DefaultRequest()

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PutResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PutResultConfigHandlerTests.cs
@@ -17,7 +17,7 @@ public sealed class PutResultConfigHandlerTests : ResultHandlersTestsBase<PutRes
     protected override PutResultConfigHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PutResultConfigRequest>? validator = null)
     {
         return new PutResultConfigHandler(logger, dbContext,
-            new IValidator<PutResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<PutResultConfigRequest>() }, accessMockHelper.LeagueProvider);
+            new IValidator<PutResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<PutResultConfigRequest>() });
     }
 
     private PutResultConfigRequest DefaultRequest(long resultConfigId)

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PutResultConfigHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/PutResultConfigHandlerTests.cs
@@ -17,10 +17,10 @@ public sealed class PutResultConfigHandlerTests : ResultHandlersTestsBase<PutRes
     protected override PutResultConfigHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PutResultConfigRequest>? validator = null)
     {
         return new PutResultConfigHandler(logger, dbContext,
-            new IValidator<PutResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<PutResultConfigRequest>() });
+            new IValidator<PutResultConfigRequest>[] { validator ?? MockHelpers.TestValidator<PutResultConfigRequest>() }, accessMockHelper.LeagueProvider);
     }
 
-    private PutResultConfigRequest DefaultRequest(long leagueId, long resultConfigId)
+    private PutResultConfigRequest DefaultRequest(long resultConfigId)
     {
         var PutResultConfig = new PutResultConfigModel()
         {
@@ -28,18 +28,17 @@ public sealed class PutResultConfigHandlerTests : ResultHandlersTestsBase<PutRes
             DisplayName = "TestResultConfig DisplayName",
             ResultsPerTeam = 10,
         };
-        return new PutResultConfigRequest(leagueId, resultConfigId, DefaultUser(), PutResultConfig);
+        return new PutResultConfigRequest(resultConfigId, DefaultUser(), PutResultConfig);
     }
 
     protected override PutResultConfigRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestResultConfigId);
+        return DefaultRequest(TestResultConfigId);
     }
 
     protected override void DefaultAssertions(PutResultConfigRequest request, ResultConfigModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ResultConfigId.Should().Be(request.ResultConfigId);
         result.Name.Should().Be(expected.Name);
         result.DisplayName.Should().Be(expected.DisplayName);
@@ -62,9 +61,10 @@ public sealed class PutResultConfigHandlerTests : ResultHandlersTestsBase<PutRes
     {
         leagueId ??= TestLeagueId;
         resultConfigId ??= TestResultConfigId;
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
         using var dbContext = accessMockHelper.CreateMockDbContext(databaseName);
         var handler = CreateTestHandler(dbContext);
-        var request = DefaultRequest(leagueId.Value, resultConfigId.Value);
+        var request = DefaultRequest(resultConfigId.Value);
         var act = () => handler.Handle(request, default);
         await act.Should().ThrowAsync<ResourceNotFoundException>();
     }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/UploadResultHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/UploadResultHandlerTests.cs
@@ -62,7 +62,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         var result = await CreateFakeResult(false, false, 1);
         result.session_results.First().results = result.session_results.First().results.Concat(newMemberRows).ToArray();
         var sut = CreateSut();
-        var request = CreateRequest(TestLeagueId, TestEventId, result);
+        var request = CreateRequest(TestEventId, result);
 
         await sut.Handle(request, default);
 
@@ -89,7 +89,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         dbContext.Events.Add(@event);
         await dbContext.SaveChangesAsync();
         var result = await CreateFakeResult();
-        var request = CreateRequest(@event.LeagueId, @event.EventId, result);
+        var request = CreateRequest(@event.EventId, result);
         var sut = CreateSut();
 
         await sut.Handle(request, default);
@@ -116,7 +116,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         dbContext.Events.Add(@event);
         await dbContext.SaveChangesAsync();
         var result = await CreateFakeResult();
-        var request = CreateRequest(@event.LeagueId, @event.EventId, result);
+        var request = CreateRequest(@event.EventId, result);
         var sut = CreateSut();
 
         await sut.Handle(request, default);
@@ -142,7 +142,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         dbContext.Events.Add(@event);
         await dbContext.SaveChangesAsync();
         var result = await CreateFakeResult();
-        var request = CreateRequest(@event.LeagueId, @event.EventId, result);
+        var request = CreateRequest(@event.EventId, result);
         var sut = CreateSut();
 
         await sut.Handle(request, default);
@@ -170,7 +170,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         dbContext.Events.Add(@event);
         await dbContext.SaveChangesAsync();
         var result = await CreateFakeResult(raceCount: sessionCount);
-        var request = CreateRequest(@event.LeagueId, @event.EventId, result);
+        var request = CreateRequest(@event.EventId, result);
         var sut = CreateSut();
 
         await sut.Handle(request, default);
@@ -205,7 +205,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         dbContext.Events.Add(@event);
         await dbContext.SaveChangesAsync();
         var result = await CreateFakeResult(false, false, 1);
-        var request = CreateRequest(@event.LeagueId, @event.EventId, result);
+        var request = CreateRequest(@event.EventId, result);
         var sut = CreateSut();
 
         await sut.Handle(request, default);
@@ -267,7 +267,7 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         var setupRow = result.session_results[0].results.Last();
         setupRow.interval = -1;
         setupRow.laps_complete = maxLaps - lapsDown;
-        var request = CreateRequest(@event.LeagueId, @event.EventId, result);
+        var request = CreateRequest(@event.EventId, result);
         var sut = CreateSut();
 
         await sut.Handle(request, default);
@@ -283,9 +283,9 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
     private IPostprocessComposer<EventEntity> EventBuilder()
     {
         return fixture.Build<EventEntity>()
-            .With(x => x.LeagueId, dbContext.Leagues.Select(x => x.Id).Max())
             .With(x => x.Schedule, dbContext.Schedules.First())
             .With(x => x.EventId, () => dbContext.Events.Select(x => x.EventId).Max() + 1)
+            .Without(x => x.LeagueId)
             .Without(x => x.EventResult)
             .Without(x => x.ResultConfigs)
             .Without(x => x.ScoredEventResults)
@@ -308,9 +308,9 @@ public sealed class UploadResultHandlerTests : DataAccessTestsBase
         return new UploadResultHandler(logger, dbContext, Array.Empty<IValidator<UploadResultRequest>>(), calculationQueue);
     }
 
-    private UploadResultRequest CreateRequest(long leagueId, long eventId, ParseSimSessionResult data)
+    private UploadResultRequest CreateRequest(long eventId, ParseSimSessionResult data)
     {
-        return new UploadResultRequest(leagueId, eventId, data);
+        return new UploadResultRequest(eventId, data);
     }
 
     private async Task<ParseSimSessionResult> CreateFakeResult(bool practice = true,

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/DeleteReviewCommentHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/DeleteReviewCommentHandlerTests.cs
@@ -18,15 +18,15 @@ public sealed class DeleteReviewCommentHandlerTests : ReviewsHandlersTestsBase<D
         return new DeleteReviewCommentHandler(logger, dbContext, new[] { validator });
     }
 
-    private DeleteReviewCommentRequest DefaultRequest(long leagueId, long commentId)
+    private DeleteReviewCommentRequest DefaultRequest(long commentId)
     {
 
-        return new DeleteReviewCommentRequest(leagueId, commentId);
+        return new DeleteReviewCommentRequest(commentId);
     }
 
     protected override DeleteReviewCommentRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestCommentId);
+        return DefaultRequest(TestCommentId);
     }
 
     protected override void DefaultPreTestAssertions(DeleteReviewCommentRequest request, LeagueDbContext dbContext)
@@ -61,7 +61,8 @@ public sealed class DeleteReviewCommentHandlerTests : ReviewsHandlersTestsBase<D
     {
         leagueId ??= TestLeagueId;
         commentId ??= TestCommentId;
-        var request = DefaultRequest(leagueId.Value, commentId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(commentId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/DeleteReviewHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/DeleteReviewHandlerTests.cs
@@ -18,15 +18,15 @@ public sealed class DeleteReviewHandlerTests : ReviewsHandlersTestsBase<DeleteRe
         return new DeleteReviewHandler(logger, dbContext, new[] { validator });
     }
 
-    private DeleteReviewRequest DefaultRequest(long leagueId, long reviewId)
+    private DeleteReviewRequest DefaultRequest(long reviewId)
     {
 
-        return new DeleteReviewRequest(leagueId, reviewId);
+        return new DeleteReviewRequest(reviewId);
     }
 
     protected override DeleteReviewRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestReviewId);
+        return DefaultRequest(TestReviewId);
     }
 
     protected override void DefaultAssertions(DeleteReviewRequest request, Unit result, LeagueDbContext dbContext)
@@ -35,13 +35,6 @@ public sealed class DeleteReviewHandlerTests : ReviewsHandlersTestsBase<DeleteRe
             .SingleOrDefault(x => x.ReviewId == request.ReviewId);
         deletedReview.Should().BeNull();
         base.DefaultAssertions(request, result, dbContext);
-    }
-
-    private void AssertMemberInfo(MemberEntity expected, MemberInfoModel result)
-    {
-        result.MemberId.Should().Be(expected.Id);
-        result.FirstName.Should().Be(expected.Firstname);
-        result.LastName.Should().Be(expected.Lastname);
     }
 
     [Fact]
@@ -59,7 +52,8 @@ public sealed class DeleteReviewHandlerTests : ReviewsHandlersTestsBase<DeleteRe
     {
         leagueId ??= TestLeagueId;
         reviewId ??= TestReviewId;
-        var request = DefaultRequest(leagueId.Value, reviewId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(reviewId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/GetReviewCommentHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/GetReviewCommentHandlerTests.cs
@@ -15,15 +15,15 @@ public sealed class GetReviewCommentHandlerTests : ReviewsHandlersTestsBase<GetR
         return new GetReviewCommentHandler(logger, dbContext, new[] { validator });
     }
 
-    private GetReviewCommentRequest DefaultRequest(long leagueId, long commentId)
+    private GetReviewCommentRequest DefaultRequest(long commentId)
     {
 
-        return new GetReviewCommentRequest(leagueId, commentId);
+        return new GetReviewCommentRequest(commentId);
     }
 
     protected override GetReviewCommentRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestCommentId);
+        return DefaultRequest(TestCommentId);
     }
 
     protected override void DefaultAssertions(GetReviewCommentRequest request, ReviewCommentModel result, LeagueDbContext dbContext)
@@ -83,7 +83,8 @@ public sealed class GetReviewCommentHandlerTests : ReviewsHandlersTestsBase<GetR
     {
         leagueId ??= TestLeagueId;
         commentId ??= TestCommentId;
-        var request = DefaultRequest(leagueId.Value, commentId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(commentId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/GetReviewHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/GetReviewHandlerTests.cs
@@ -15,19 +15,18 @@ public sealed class GetReviewHandlerTests : ReviewsHandlersTestsBase<GetReviewHa
         return new GetReviewHandler(logger, dbContext, new[] { validator });
     }
 
-    private GetReviewRequest DefaultRequest(long leagueId, long reviewId, bool includeComments = true)
+    private GetReviewRequest DefaultRequest(long reviewId, bool includeComments = true)
     {
-        return new GetReviewRequest(leagueId, reviewId, includeComments);
+        return new GetReviewRequest(reviewId, includeComments);
     }
 
     protected override GetReviewRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestReviewId);
+        return DefaultRequest(TestReviewId);
     }
 
     protected override void DefaultAssertions(GetReviewRequest request, ReviewModel result, LeagueDbContext dbContext)
     {
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ReviewId.Should().Be(request.ReviewId);
         var reviewEntity = dbContext.IncidentReviews
             .Include(x => x.Session)
@@ -93,7 +92,8 @@ public sealed class GetReviewHandlerTests : ReviewsHandlersTestsBase<GetReviewHa
     {
         leagueId ??= TestLeagueId;
         reviewId ??= TestReviewId;
-        var request = DefaultRequest(leagueId.Value, reviewId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(reviewId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 
@@ -106,7 +106,7 @@ public sealed class GetReviewHandlerTests : ReviewsHandlersTestsBase<GetReviewHa
     [Fact]
     public async Task ShouldNotIncludeCommentsWhenFalse()
     {
-        var request = DefaultRequest(TestLeagueId, TestReviewId, false);
+        var request = DefaultRequest(TestReviewId, false);
         await HandleSpecialAsync(request, (request, model, context) =>
         {
             model.ReviewId.Should().Be(TestReviewId);

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PostReviewCommentToReviewHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PostReviewCommentToReviewHandlerTests.cs
@@ -24,15 +24,15 @@ public sealed class PostReviewCommentToReviewHandlerTests : ReviewsHandlersTests
         return new PostReviewCommentToReviewHandler(logger, dbContext, new[] { validator });
     }
 
-    private PostReviewCommentToReviewRequest DefaultRequest(long leagueId, long reviewId)
+    private PostReviewCommentToReviewRequest DefaultRequest(long reviewId)
     {
 
-        return new PostReviewCommentToReviewRequest(leagueId, reviewId, DefaultUser(), TestReviewComment);
+        return new PostReviewCommentToReviewRequest(reviewId, DefaultUser(), TestReviewComment);
     }
 
     protected override PostReviewCommentToReviewRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestReviewId);
+        return DefaultRequest(TestReviewId);
     }
 
     protected override void DefaultAssertions(PostReviewCommentToReviewRequest request, ReviewCommentModel result, LeagueDbContext dbContext)
@@ -76,7 +76,8 @@ public sealed class PostReviewCommentToReviewHandlerTests : ReviewsHandlersTests
     {
         leagueId ??= TestLeagueId;
         reviewId ??= TestReviewId;
-        var request = DefaultRequest(leagueId.Value, reviewId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(reviewId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PostReviewToSessionHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PostReviewToSessionHandlerTests.cs
@@ -30,20 +30,19 @@ public sealed class PostReviewToSessionHandlerTests : ReviewsHandlersTestsBase<P
         return new PostReviewToSessionHandler(logger, dbContext, new[] { validator });
     }
 
-    private PostReviewToSessionRequest DefaultRequest(long leagueId, long sessionId)
+    private PostReviewToSessionRequest DefaultRequest(long sessionId)
     {
-        return new PostReviewToSessionRequest(leagueId, sessionId, DefaultUser(), TestReviewModel);
+        return new PostReviewToSessionRequest(sessionId, DefaultUser(), TestReviewModel);
     }
 
     protected override PostReviewToSessionRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestSessionId);
+        return DefaultRequest(TestSessionId);
     }
 
     protected override void DefaultAssertions(PostReviewToSessionRequest request, ReviewModel result, LeagueDbContext dbContext)
     {
         var expected = TestReviewModel;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.SessionId.Should().Be(request.SessionId);
         result.ReviewId.Should().NotBe(0);
         result.Corner.Should().Be(expected.Corner);
@@ -88,7 +87,8 @@ public sealed class PostReviewToSessionHandlerTests : ReviewsHandlersTestsBase<P
     {
         leagueId ??= TestLeagueId;
         sessionId ??= TestSessionId;
-        var request = DefaultRequest(leagueId.Value, sessionId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(sessionId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PutReviewCommentHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PutReviewCommentHandlerTests.cs
@@ -24,21 +24,20 @@ public sealed class PutReviewCommentHandlerTests : ReviewsHandlersTestsBase<PutR
         return new PutReviewCommentHandler(logger, dbContext, new[] { validator });
     }
 
-    private PutReviewCommentRequest DefaultRequest(long leagueId, long commentId)
+    private PutReviewCommentRequest DefaultRequest(long commentId)
     {
 
-        return new PutReviewCommentRequest(leagueId, commentId, DefaultUser(), TestReviewComment);
+        return new PutReviewCommentRequest(commentId, DefaultUser(), TestReviewComment);
     }
 
     protected override PutReviewCommentRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestCommentId);
+        return DefaultRequest(TestCommentId);
     }
 
     protected override void DefaultAssertions(PutReviewCommentRequest request, ReviewCommentModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.CommentId.Should().Be(request.CommentId);
         result.Text.Should().Be(expected.Text);
         result.Votes.Should().HaveSameCount(expected.Votes);
@@ -76,7 +75,8 @@ public sealed class PutReviewCommentHandlerTests : ReviewsHandlersTestsBase<PutR
     {
         leagueId ??= TestLeagueId;
         reviewId ??= TestReviewId;
-        var request = DefaultRequest(leagueId.Value, reviewId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(reviewId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PutReviewHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Reviews/PutReviewHandlerTests.cs
@@ -38,21 +38,20 @@ public sealed class PutReviewHandlerTests : ReviewsHandlersTestsBase<PutReviewHa
         return new PutReviewHandler(logger, dbContext, new[] { validator });
     }
 
-    private PutReviewRequest DefaultRequest(long leagueId, long reviewId)
+    private PutReviewRequest DefaultRequest(long reviewId)
     {
 
-        return new PutReviewRequest(leagueId, reviewId, DefaultUser(), TestReviewModel);
+        return new PutReviewRequest(reviewId, DefaultUser(), TestReviewModel);
     }
 
     protected override PutReviewRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestReviewId);
+        return DefaultRequest(TestReviewId);
     }
 
     protected override void DefaultAssertions(PutReviewRequest request, ReviewModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ReviewId.Should().Be(request.ReviewId);
         result.Corner.Should().Be(expected.Corner);
         result.OnLap.Should().Be(expected.OnLap);
@@ -104,7 +103,8 @@ public sealed class PutReviewHandlerTests : ReviewsHandlersTestsBase<PutReviewHa
     {
         leagueId ??= TestLeagueId;
         reviewId ??= TestReviewId;
-        var request = DefaultRequest(leagueId.Value, reviewId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(reviewId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/DeleteScheduleHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/DeleteScheduleHandlerTests.cs
@@ -19,12 +19,12 @@ public sealed class DeleteScheduleDbTestFixture : HandlersTestsBase<DeleteSchedu
 
     protected override DeleteScheduleRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestScheduleId);
+        return DefaultRequest(TestScheduleId);
     }
 
-    private DeleteScheduleRequest DefaultRequest(long leagueId, long scheduleId)
+    private DeleteScheduleRequest DefaultRequest(long scheduleId)
     {
-        return new DeleteScheduleRequest(leagueId, scheduleId);
+        return new DeleteScheduleRequest(scheduleId);
     }
 
     protected override void DefaultPreTestAssertions(DeleteScheduleRequest request, LeagueDbContext dbContext)
@@ -60,7 +60,8 @@ public sealed class DeleteScheduleDbTestFixture : HandlersTestsBase<DeleteSchedu
     {
         leagueId ??= TestLeagueId;
         scheduleId ??= TestScheduleId;
-        var request = DefaultRequest(leagueId.Value, scheduleId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(scheduleId.Value);
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/GetScheduleHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/GetScheduleHandlerTests.cs
@@ -20,17 +20,16 @@ public sealed class GetScheduleDbTestFixture : HandlersTestsBase<GetScheduleHand
 
     protected override GetScheduleRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestScheduleId);
+        return DefaultRequest(TestScheduleId);
     }
 
-    private GetScheduleRequest DefaultRequest(long leagueId, long scheduleId)
+    private GetScheduleRequest DefaultRequest(long scheduleId)
     {
-        return new GetScheduleRequest(leagueId, scheduleId);
+        return new GetScheduleRequest(scheduleId);
     }
 
     protected override void DefaultAssertions(GetScheduleRequest request, ScheduleModel result, LeagueDbContext dbContext)
     {
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ScheduleId.Should().Be(request.ScheduleId);
         var scheduleEntity = dbContext.Schedules
             .Include(x => x.Events)
@@ -64,7 +63,8 @@ public sealed class GetScheduleDbTestFixture : HandlersTestsBase<GetScheduleHand
     {
         leagueId ??= TestLeagueId;
         scheduleId ??= TestScheduleId;
-        var request = DefaultRequest(leagueId.Value, scheduleId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(scheduleId.Value);
         await base.HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/GetSchedulesHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/GetSchedulesHandlerTests.cs
@@ -19,12 +19,7 @@ public sealed class GetSchedulesDbTestFixture : HandlersTestsBase<GetSchedulesHa
 
     protected override GetSchedulesRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId);
-    }
-
-    private GetSchedulesRequest DefaultRequest(long leagueId)
-    {
-        return new GetSchedulesRequest(leagueId);
+        return new GetSchedulesRequest();
     }
 
     protected override void DefaultAssertions(GetSchedulesRequest request, IEnumerable<ScheduleModel> result, LeagueDbContext dbContext)
@@ -52,7 +47,8 @@ public sealed class GetSchedulesDbTestFixture : HandlersTestsBase<GetSchedulesHa
     [InlineData(-43)]
     public async Task HandleNotFoundAsync(long leagueId)
     {
-        var request = DefaultRequest(leagueId);
+        accessMockHelper.SetCurrentLeague(leagueId);
+        var request = DefaultRequest();
         await base.HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/PostScheduleHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/PostScheduleHandlerTests.cs
@@ -21,22 +21,21 @@ public sealed class PostScheduleDbTestFixture : HandlersTestsBase<PostScheduleHa
 
     protected override PostScheduleRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestSeasonId);
+        return DefaultRequest(TestSeasonId);
     }
 
-    private PostScheduleRequest DefaultRequest(long leagueId, long seasonId)
+    private PostScheduleRequest DefaultRequest(long seasonId)
     {
         var model = new PostScheduleModel()
         {
             Name = testScheduleName
         };
-        return new PostScheduleRequest(leagueId, seasonId, DefaultUser(), model);
+        return new PostScheduleRequest(seasonId, DefaultUser(), model);
     }
 
     protected override void DefaultAssertions(PostScheduleRequest request, ScheduleModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ScheduleId.Should().NotBe(0);
         result.Name.Should().Be(expected.Name);
         AssertCreated(request.User, DateTime.UtcNow, result);
@@ -64,7 +63,8 @@ public sealed class PostScheduleDbTestFixture : HandlersTestsBase<PostScheduleHa
     {
         leagueId ??= TestLeagueId;
         seasonId ??= TestSeasonId;
-        var request = DefaultRequest(leagueId.Value, seasonId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(seasonId.Value);
         await base.HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/PutScheduleHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Schedules/PutScheduleHandlerTests.cs
@@ -21,22 +21,21 @@ public sealed class PutScheduleDbTestFixture : HandlersTestsBase<PutScheduleHand
 
     protected override PutScheduleRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestScheduleId);
+        return DefaultRequest(TestScheduleId);
     }
 
-    private PutScheduleRequest DefaultRequest(long leagueId, long scheduleId)
+    private PutScheduleRequest DefaultRequest(long scheduleId)
     {
         var model = new PutScheduleModel()
         {
             Name = testScheduleName
         };
-        return new PutScheduleRequest(leagueId, DefaultUser(), scheduleId, model);
+        return new PutScheduleRequest(DefaultUser(), scheduleId, model);
     }
 
     protected override void DefaultAssertions(PutScheduleRequest request, ScheduleModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
         result.ScheduleId.Should().Be(request.ScheduleId);
         result.Name.Should().Be(expected.Name);
         AssertChanged(request.User, DateTime.UtcNow, result);
@@ -64,7 +63,8 @@ public sealed class PutScheduleDbTestFixture : HandlersTestsBase<PutScheduleHand
     {
         leagueId ??= TestLeagueId;
         scheduleId ??= TestScheduleId;
-        var request = DefaultRequest(leagueId.Value, scheduleId.Value);
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(scheduleId.Value);
         await base.HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/DeleteSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/DeleteSeasonHandlerTests.cs
@@ -22,13 +22,13 @@ public sealed class DeleteSeasonDbTestFixture : HandlersTestsBase<DeleteSeasonHa
 
     protected override DeleteSeasonRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestSeasonId);
+        return DefaultRequest(TestSeasonId);
     }
 
-    private DeleteSeasonRequest DefaultRequest(long leagueId, long seasonId)
+    private DeleteSeasonRequest DefaultRequest(long seasonId)
     {
 
-        return new DeleteSeasonRequest(leagueId, seasonId);
+        return new DeleteSeasonRequest(seasonId);
     }
 
     protected override void DefaultPreTestAssertions(DeleteSeasonRequest request, LeagueDbContext dbContext)
@@ -60,7 +60,8 @@ public sealed class DeleteSeasonDbTestFixture : HandlersTestsBase<DeleteSeasonHa
     [InlineData(1, -42)]
     public async Task HandleNotFound(long leagueId, long seasonId)
     {
-        var request = DefaultRequest(leagueId, seasonId);
+        accessMockHelper.SetCurrentLeague(leagueId);
+        var request = DefaultRequest(seasonId);
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/GetSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/GetSeasonHandlerTests.cs
@@ -20,12 +20,12 @@ public sealed class GetSeasonDbTestFixture : HandlersTestsBase<GetSeasonHandler,
 
     protected override GetSeasonRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestSeasonId);
+        return DefaultRequest(TestSeasonId);
     }
 
-    private GetSeasonRequest DefaultRequest(long leagueId, long seasonId)
+    private GetSeasonRequest DefaultRequest(long seasonId)
     {
-        return new GetSeasonRequest(leagueId, seasonId);
+        return new GetSeasonRequest(seasonId);
     }
 
     protected override void DefaultAssertions(GetSeasonRequest request, SeasonModel result, LeagueDbContext dbContext)
@@ -33,7 +33,6 @@ public sealed class GetSeasonDbTestFixture : HandlersTestsBase<GetSeasonHandler,
         var testSeason = dbContext.Seasons
             .Include(x => x.Schedules)
             .First(x => x.SeasonId == request.SeasonId);
-        result.LeagueId.Should().Be(request.LeagueId);
         result.SeasonId.Should().Be(request.SeasonId);
         result.Finished.Should().Be(testSeason.Finished);
         result.HideComments.Should().Be(testSeason.HideCommentsBeforeVoted);
@@ -68,7 +67,8 @@ public sealed class GetSeasonDbTestFixture : HandlersTestsBase<GetSeasonHandler,
     [InlineData(-42, 1)]
     public async Task HandleNotFound(long leagueId, long seasonId)
     {
-        var request = DefaultRequest(leagueId, seasonId);
+        accessMockHelper.SetCurrentLeague(leagueId);
+        var request = DefaultRequest(seasonId);
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/GetSeasonsHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/GetSeasonsHandlerTests.cs
@@ -19,12 +19,7 @@ public sealed class GetSeasonsDbTestFixture : HandlersTestsBase<GetSeasonsHandle
 
     protected override GetSeasonsRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId);
-    }
-
-    private GetSeasonsRequest DefaultRequest(long leagueId)
-    {
-        return new GetSeasonsRequest(leagueId);
+        return new GetSeasonsRequest();
     }
 
     [Fact]
@@ -44,7 +39,8 @@ public sealed class GetSeasonsDbTestFixture : HandlersTestsBase<GetSeasonsHandle
     [InlineData(-42)]
     public async Task HandleNotFound(long leagueId)
     {
-        var request = DefaultRequest(leagueId);
+        accessMockHelper.SetCurrentLeague(leagueId);
+        var request = DefaultRequest();
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/PostSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/PostSeasonHandlerTests.cs
@@ -16,7 +16,7 @@ public sealed class PostSeasonHandlerTests : HandlersTestsBase<PostSeasonHandler
 
     protected override PostSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PostSeasonRequest> validator)
     {
-        return new PostSeasonHandler(logger, dbContext, new IValidator<PostSeasonRequest>[] { validator }, accessMockHelper.LeagueProvider);
+        return new PostSeasonHandler(logger, dbContext, new IValidator<PostSeasonRequest>[] { validator });
     }
 
     protected override PostSeasonRequest DefaultRequest()

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/PostSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/PostSeasonHandlerTests.cs
@@ -6,37 +6,32 @@ using iRLeagueDatabaseCore.Models;
 
 namespace iRLeagueApiCore.UnitTests.Server.Handlers.Seasons;
 
-public sealed class PostSeasonDbTestFixture : HandlersTestsBase<PostSeasonHandler, PostSeasonRequest, SeasonModel>
+public sealed class PostSeasonHandlerTests : HandlersTestsBase<PostSeasonHandler, PostSeasonRequest, SeasonModel>
 {
     private const string testSeasonName = "TestSeason";
 
-    public PostSeasonDbTestFixture() : base()
+    public PostSeasonHandlerTests() : base()
     {
     }
 
     protected override PostSeasonHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<PostSeasonRequest> validator)
     {
-        return new PostSeasonHandler(logger, dbContext, new IValidator<PostSeasonRequest>[] { validator });
+        return new PostSeasonHandler(logger, dbContext, new IValidator<PostSeasonRequest>[] { validator }, accessMockHelper.LeagueProvider);
     }
 
     protected override PostSeasonRequest DefaultRequest()
-    {
-        return DefaultRequest(TestLeagueId);
-    }
-
-    private PostSeasonRequest DefaultRequest(long leagueId)
     {
         var model = new PostSeasonModel()
         {
             SeasonName = testSeasonName
         };
-        return new PostSeasonRequest(leagueId, DefaultUser(), model);
+        return new PostSeasonRequest(DefaultUser(), model);
     }
 
     protected override void DefaultAssertions(PostSeasonRequest request, SeasonModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
+        result.LeagueId.Should().Be(accessMockHelper.LeagueProvider.LeagueId);
         result.SeasonId.Should().NotBe(0);
         result.Finished.Should().Be(expected.Finished);
         result.HideComments.Should().Be(expected.HideComments);
@@ -63,7 +58,8 @@ public sealed class PostSeasonDbTestFixture : HandlersTestsBase<PostSeasonHandle
     [InlineData(-42)]
     public async Task HandleNotFound(long leagueId)
     {
-        var request = DefaultRequest(leagueId);
+        accessMockHelper.SetCurrentLeague(leagueId);
+        var request = DefaultRequest();
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/PutSeasonHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Seasons/PutSeasonHandlerTests.cs
@@ -21,16 +21,16 @@ public sealed class PutSeasonDbTestFixture : HandlersTestsBase<PutSeasonHandler,
 
     protected override PutSeasonRequest DefaultRequest()
     {
-        return DefaultRequest(TestLeagueId, TestSeasonId);
+        return DefaultRequest(TestSeasonId);
     }
 
-    private PutSeasonRequest DefaultRequest(long leagueId, long seasonId)
+    private PutSeasonRequest DefaultRequest(long seasonId)
     {
         var model = new PutSeasonModel()
         {
             SeasonName = testSeasonName
         };
-        return new PutSeasonRequest(leagueId, DefaultUser(), seasonId, model);
+        return new PutSeasonRequest(DefaultUser(), seasonId, model);
     }
 
     protected override void DefaultPreTestAssertions(PutSeasonRequest request, LeagueDbContext dbContext)
@@ -41,7 +41,7 @@ public sealed class PutSeasonDbTestFixture : HandlersTestsBase<PutSeasonHandler,
     protected override void DefaultAssertions(PutSeasonRequest request, SeasonModel result, LeagueDbContext dbContext)
     {
         var expected = request.Model;
-        result.LeagueId.Should().Be(request.LeagueId);
+        result.LeagueId.Should().Be(accessMockHelper.LeagueProvider.LeagueId);
         result.SeasonId.Should().Be(request.SeasonId);
         result.Finished.Should().Be(expected.Finished);
         result.HideComments.Should().Be(expected.HideComments);
@@ -70,7 +70,8 @@ public sealed class PutSeasonDbTestFixture : HandlersTestsBase<PutSeasonHandler,
     [InlineData(-42, 1)]
     public async Task HandleNotFound(long leagueId, long seasonId)
     {
-        var request = DefaultRequest(leagueId, seasonId);
+        accessMockHelper.SetCurrentLeague(leagueId);
+        var request = DefaultRequest(seasonId);
         await HandleNotFoundRequestAsync(request);
     }
 }

--- a/test/iRLeagueApiCore.UnitTests/Server/Validators/Seasons/PostSeasonValidatorTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Validators/Seasons/PostSeasonValidatorTests.cs
@@ -1,28 +1,19 @@
 ﻿using FluentValidation.TestHelper;
 using iRLeagueApiCore.Common.Models;
+using iRLeagueApiCore.Mocking.DataAccess;
 using iRLeagueApiCore.Server.Handlers.Seasons;
 using iRLeagueApiCore.Server.Models;
 using iRLeagueApiCore.Server.Validation.Seasons;
-using iRLeagueApiCore.UnitTests.Fixtures;
 using iRLeagueDatabaseCore.Models;
 
 namespace iRLeagueApiCore.UnitTests.Server.Validators.Seasons;
 
-public sealed class PostSeasonDbTestFixture : IClassFixture<DbTestFixture>
+public sealed class PostSeasonValidatorTests : DataAccessTestsBase
 {
-    private readonly DbTestFixture fixture;
-
-    private long TestLeagueId => fixture.DbContext.Leagues.First().Id;
     private const string testSeasonName = "TestSeason";
 
-    public PostSeasonDbTestFixture(DbTestFixture fixture)
+    private PostSeasonRequest DefaultRequest()
     {
-        this.fixture = fixture;
-    }
-
-    private PostSeasonRequest DefaultRequest(long? leagueId = null)
-    {
-        leagueId ??= TestLeagueId;
         var model = new PostSeasonModel()
         {
             HideComments = true,
@@ -30,7 +21,7 @@ public sealed class PostSeasonDbTestFixture : IClassFixture<DbTestFixture>
             Finished = true,
             SeasonName = testSeasonName,
         };
-        return new PostSeasonRequest(leagueId.Value, LeagueUser.Empty, model);
+        return new PostSeasonRequest(LeagueUser.Empty, model);
     }
 
     private static PostSeasonRequestValidator CreateValidator(LeagueDbContext dbContext)
@@ -39,29 +30,11 @@ public sealed class PostSeasonDbTestFixture : IClassFixture<DbTestFixture>
     }
 
     [Theory]
-    [InlineData(null, true)]
-    [InlineData(0, false)]
-    public async Task ValidateLeagueId(long? leagueId, bool expectValid)
-    {
-        leagueId ??= TestLeagueId;
-        var dbContext = fixture.CreateDbContext();
-        var request = DefaultRequest(leagueId);
-        var validator = CreateValidator(dbContext);
-        var result = await validator.TestValidateAsync(request);
-        Assert.Equal(expectValid, result.IsValid);
-        if (expectValid == false)
-        {
-            result.ShouldHaveValidationErrorFor(x => x.LeagueId);
-        }
-    }
-
-    [Theory]
     [InlineData("ValidName", true)]
     [InlineData("", false)]
     [InlineData(null, false)]
     public async Task ValidateSeasonName(string name, bool expectValid)
     {
-        var dbContext = fixture.CreateDbContext();
         var request = DefaultRequest();
         request.Model.SeasonName = name;
         var validator = CreateValidator(dbContext);

--- a/test/iRLeagueApiCore.UnitTests/Server/Validators/Seasons/PutSeasonValidatorTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Validators/Seasons/PutSeasonValidatorTests.cs
@@ -1,27 +1,20 @@
 ﻿using FluentValidation.TestHelper;
 using iRLeagueApiCore.Common.Models;
+using iRLeagueApiCore.Mocking.DataAccess;
 using iRLeagueApiCore.Server.Handlers.Seasons;
 using iRLeagueApiCore.Server.Models;
 using iRLeagueApiCore.Server.Validation.Seasons;
-using iRLeagueApiCore.UnitTests.Fixtures;
 using iRLeagueDatabaseCore.Models;
 
 namespace iRLeagueApiCore.UnitTests.Server.Validators.Seasons;
 
-public sealed class PutSeasonDbTestFixture : IClassFixture<DbTestFixture>
+public sealed class PutSeasonValidatorTests : DataAccessTestsBase
 {
-    private readonly DbTestFixture fixture;
-
     private const long testLeagueId = 1;
     private const long testSeasonId = 1;
     private const string testSeasonName = "TestSeason";
 
-    public PutSeasonDbTestFixture(DbTestFixture fixture)
-    {
-        this.fixture = fixture;
-    }
-
-    private static PutSeasonRequest DefaultRequest(long leagueId = testLeagueId, long seasonId = testSeasonId)
+    private static PutSeasonRequest DefaultRequest(long seasonId = testSeasonId)
     {
         var model = new PutSeasonModel()
         {
@@ -30,7 +23,7 @@ public sealed class PutSeasonDbTestFixture : IClassFixture<DbTestFixture>
             Finished = true,
             SeasonName = testSeasonName,
         };
-        return new PutSeasonRequest(leagueId, LeagueUser.Empty, seasonId, model);
+        return new PutSeasonRequest(LeagueUser.Empty, seasonId, model);
     }
 
     private static PutSeasonRequestValidator CreateValidator(LeagueDbContext dbContext)
@@ -41,25 +34,8 @@ public sealed class PutSeasonDbTestFixture : IClassFixture<DbTestFixture>
     [Theory]
     [InlineData(1, true)]
     [InlineData(0, false)]
-    public async Task ValidateLeagueId(long leagueId, bool expectValid)
-    {
-        using var dbContext = fixture.CreateDbContext();
-        var request = DefaultRequest(leagueId);
-        var validator = CreateValidator(dbContext);
-        var result = await validator.TestValidateAsync(request);
-        Assert.Equal(expectValid, result.IsValid);
-        if (expectValid == false)
-        {
-            result.ShouldHaveValidationErrorFor(x => x.LeagueId);
-        }
-    }
-
-    [Theory]
-    [InlineData(1, true)]
-    [InlineData(0, false)]
     public async Task ValidateSeasonId(long seasonId, bool expectValid)
     {
-        using var dbContext = fixture.CreateDbContext();
         var request = DefaultRequest(seasonId: seasonId);
         var validator = CreateValidator(dbContext);
         var result = await validator.TestValidateAsync(request);
@@ -76,7 +52,6 @@ public sealed class PutSeasonDbTestFixture : IClassFixture<DbTestFixture>
     [InlineData(null, false)]
     public async Task ValidateSeasonName(string name, bool expectValid)
     {
-        using var dbContext = fixture.CreateDbContext();
         var request = DefaultRequest();
         request.Model.SeasonName = name;
         var validator = CreateValidator(dbContext);

--- a/test/iRLeagueApiCore.UnitTests/iRLeagueApiCore.UnitTests.csproj
+++ b/test/iRLeagueApiCore.UnitTests/iRLeagueApiCore.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="FluentIdentityBuilder" Version="0.0.3" />
     <PackageReference Include="iRLeagueApiCore.Common" Version="0.6.4" />
-    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.2" />
+    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
       <PrivateAssets>all</PrivateAssets>

--- a/test/iRLeagueApiCore.UnitTests/iRLeagueApiCore.UnitTests.csproj
+++ b/test/iRLeagueApiCore.UnitTests/iRLeagueApiCore.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="FluentIdentityBuilder" Version="0.0.3" />
     <PackageReference Include="iRLeagueApiCore.Common" Version="0.6.4" />
-    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.4" />
+    <PackageReference Include="iRLeagueDatabaseCore" Version="0.6.5-dev.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Use tenant provider instead of setting LeagueId for each request
* Tenant (leagueId) is set by `[InsertLeagueIdAttribute]` automatically.
* All requests from inside the Controller Endpoint do not need to filter the query for league id anymore