### PR TITLE
[B] Delete results clean

### DIFF
--- a/src/iRLeagueApiCore.Server/Controllers/AuthenticateController.cs
+++ b/src/iRLeagueApiCore.Server/Controllers/AuthenticateController.cs
@@ -179,7 +179,7 @@ public sealed class AuthenticateController : Controller
         }
         var request = new RegisterUserRequest(model, linkTemplate);
         var (user, result) = await mediator.Send(request);
-        if (result.Succeeded)
+        if (result.Succeeded && user is not null)
         {
             return CreatedAtAction(nameof(UsersController.GetUser), "Users", new { id = user.UserId }, user);
         }

--- a/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultHandler.cs
@@ -12,11 +12,15 @@ public sealed class DeleteResultHandler : ResultHandlerBase<DeleteResultHandler,
     public override async Task<Unit> Handle(DeleteResultRequest request, CancellationToken cancellationToken)
     {
         await validators.ValidateAllAndThrowAsync(request, cancellationToken);
-        var deleteEventResults = await GetScoredEventResults(request.EventId, cancellationToken);
-        var deleteStandings = await GetEventStandings(request.EventId, cancellationToken);
+        var @event = await dbContext.Events
+            .Where(x => x.EventId == request.EventId)
+            .FirstOrDefaultAsync(cancellationToken)
+            ?? throw new ResourceNotFoundException();
+        var deleteEventResults = await GetScoredEventResults(@event.EventId, cancellationToken);
+        var deleteStandings = await GetEventStandings(@event.EventId, cancellationToken);
         foreach (var result in deleteEventResults)
         {
-            dbContext.ScoredEventResults.Remove(result);
+            await SafeDeleteScoredEventResult(result);
         }
         foreach (var standing in deleteStandings)
         {
@@ -38,5 +42,24 @@ public sealed class DeleteResultHandler : ResultHandlerBase<DeleteResultHandler,
         return await dbContext.Standings
             .Where(x => x.EventId == eventId)
             .ToListAsync(cancellationToken);
+    }
+
+    private async Task SafeDeleteScoredEventResult(ScoredEventResultEntity eventResult)
+    {
+        foreach (var sessionResult in eventResult.ScoredSessionResults)
+        {
+            await SafeDeleteScoredSessionResult(sessionResult);
+        }
+        dbContext.Remove(eventResult);
+    }
+
+    private async Task SafeDeleteScoredSessionResult(ScoredSessionResultEntity sessionResult)
+    {
+        // Delete penalties
+        var penalties = sessionResult.ScoredResultRows
+            .SelectMany(x => x.AddPenalties)
+            .ToList();
+        dbContext.RemoveRange(penalties);
+        dbContext.Remove(sessionResult);
     }
 }

--- a/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultHandler.cs
+++ b/src/iRLeagueApiCore.Server/Handlers/Results/DeleteResultHandler.cs
@@ -34,6 +34,9 @@ public sealed class DeleteResultHandler : ResultHandlerBase<DeleteResultHandler,
     {
         return await dbContext.ScoredEventResults
             .Where(x => x.EventId == eventId)
+            .Include(x => x.ScoredSessionResults)
+                .ThenInclude(x => x.ScoredResultRows)
+                    .ThenInclude(x => x.AddPenalties)
             .ToListAsync(cancellationToken);
     }
 

--- a/test/DbIntegrationTests/DbIntegrationTests.cs
+++ b/test/DbIntegrationTests/DbIntegrationTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using iRLeagueApiCore.Common.Models;
+using iRLeagueApiCore.Server.Handlers.Results;
 using iRLeagueDatabaseCore.Models;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -197,32 +198,6 @@ public class DbIntegrationTests : DatabaseTestBase
         }
     }
 
-    //[Fact]
-    //public async Task ShouldCascadeDeleteFilter()
-    //{
-    //    using var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-    //    long filterOptionId;
-    //    using (var context = GetTestDatabaseContext())
-    //    {
-    //        SetCurrentLeague(await context.Leagues.FirstAsync());
-    //        var filterOption = new FilterOptionEntity();
-    //        var config = await context.ResultConfigurations.FirstAsync();
-    //        config.PointFilters.Add(filterOption);
-    //        await context.SaveChangesAsync();
-    //        filterOptionId = filterOption.FilterOptionId;
-
-    //        config.PointFilters.Remove(filterOption);
-    //        var filterOptionEntry = context.Entry(filterOption);
-    //        await context.SaveChangesAsync();
-    //    }
-
-    //    using (var context = GetTestDatabaseContext())
-    //    {
-    //        var filterOption = context.FilterOptions.FirstOrDefault(x => x.FilterOptionId == filterOptionId);
-    //        Assert.Null(filterOption);
-    //    }
-    //}
-
     [Fact]
     public async Task ShouldSetFilterValues()
     {
@@ -318,6 +293,31 @@ public class DbIntegrationTests : DatabaseTestBase
             autoPenalty.Conditions.First().ColumnPropertyName.Should().Be("Incidents");
             autoPenalty.Conditions.First().FilterValues.Should().BeEquivalentTo(new[] { "4" });
             autoPenalty.Conditions.First().Action.Should().Be(iRLeagueApiCore.Common.Enums.MatchedValueAction.Remove);
+        }
+    }
+
+    [Fact]
+    public async Task ShouldDeleteResults_WithPenalties()
+    {
+        using (var context = GetTestDatabaseContext())
+        {
+            var result = await context.ScoredEventResults
+                .Include(x => x.ScoredSessionResults)
+                    .ThenInclude(x => x.ScoredResultRows)
+                        .ThenInclude(x => x.AddPenalties)
+                .FirstAsync();
+            foreach (var row in result.ScoredSessionResults.Last().ScoredResultRows.Take(2))
+            {
+                var penalty = new AddPenaltyEntity()
+                {
+                    Lap = "1",
+                    Corner = "1",
+                    Reason = "Test Penalty",
+                    Value = new() { Points = 5 },
+                };
+                row.AddPenalties.Add(penalty);
+            }
+            await context.SaveChangesAsync();
         }
     }
 

--- a/test/DbIntegrationTests/DbIntegrationTests.csproj
+++ b/test/DbIntegrationTests/DbIntegrationTests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\iRLeagueApiCore.Server\iRLeagueApiCore.Server.csproj" />
     <ProjectReference Include="..\..\src\iRLeagueDatabaseCore\iRLeagueDatabaseCore.csproj" />
   </ItemGroup>
 

--- a/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/DeleteResultHandlerTests.cs
+++ b/test/iRLeagueApiCore.UnitTests/Server/Handlers/Results/DeleteResultHandlerTests.cs
@@ -1,0 +1,107 @@
+﻿using FluentValidation;
+using iRLeagueApiCore.Server.Handlers.Results;
+using iRLeagueDatabaseCore.Models;
+using MediatR;
+using Microsoft.AspNetCore.Identity.Test;
+using Microsoft.EntityFrameworkCore;
+using System;
+
+namespace iRLeagueApiCore.UnitTests.Server.Handlers.Results;
+
+public sealed class DeleteResultHandlerTests : ResultHandlersTestsBase<DeleteResultHandler, DeleteResultRequest, Unit>
+{
+    protected override DeleteResultHandler CreateTestHandler(LeagueDbContext dbContext, IValidator<DeleteResultRequest> validator)
+    {
+        return new(logger, dbContext, [validator]);
+    }
+
+    protected override DeleteResultRequest DefaultRequest()
+    {
+        return DefaultRequest(TestEventId);
+    }
+
+    private DeleteResultRequest DefaultRequest(long eventId)
+    {
+        return new DeleteResultRequest(eventId);
+    }
+
+    protected override void DefaultAssertions(DeleteResultRequest request, Unit result, LeagueDbContext dbContext)
+    {
+        base.DefaultAssertions(request, result, dbContext);
+        var deletedResult = dbContext.ScoredEventResults
+            .Where(x => x.EventId == request.EventId)
+            .FirstOrDefault();
+        deletedResult.Should().BeNull();
+    }
+
+    [Fact]
+    public async override Task ShouldHandleDefault()
+    {
+        await base.ShouldHandleDefault();
+    }
+
+    [Fact]
+    public async override Task ShouldHandleValidationFailed()
+    {
+        await base.ShouldHandleValidationFailed();
+    }
+
+    [Theory]
+    [InlineData(0L, defaultId)]
+    [InlineData(defaultId, 0L)]
+    [InlineData(-42L, defaultId)]
+    [InlineData(defaultId, -42L)]
+    public async Task ShouldHandleNotFoundAsync(long? leagueId, long? resultId)
+    {
+        leagueId ??= TestLeagueId;
+        resultId ??= TestEventId;
+        accessMockHelper.SetCurrentLeague(leagueId.Value);
+        var request = DefaultRequest(resultId.Value);
+        await HandleNotFoundRequestAsync(request);
+    }
+
+    [Fact]
+    public async Task ShouldHandle_DeleteResult_WithPenalties()
+    {
+        using (var dbContext = accessMockHelper.CreateMockDbContext(databaseName))
+        {
+            // Add penalties to the result
+            var result = await dbContext.ScoredEventResults
+                .Where(x => x.EventId == TestEventId)
+                .FirstAsync();
+            foreach (var row in result.ScoredSessionResults.Last().ScoredResultRows.Take(2))
+            {
+                var penalty = fixture.Build<AddPenaltyEntity>()
+                    .With(x => x.ScoredResultRow, row)
+                    .Without(x => x.LeagueId)
+                    .Create();
+                row.AddPenalties.Add(penalty);
+            }
+            await dbContext.SaveChangesAsync();
+        }
+
+        using (var dbContext = accessMockHelper.CreateMockDbContext(databaseName))
+        {
+            var request = DefaultRequest(TestEventId);
+            var handler = CreateTestHandler(dbContext, MockHelpers.TestValidator<DeleteResultRequest>());
+
+            // Pre assertions
+            var addedPenalties = await dbContext.AddPenaltys
+                .Where(x => x.ScoredResultRow.ScoredSessionResult.ScoredEventResult.EventId == TestEventId)
+                .ToListAsync();
+            addedPenalties.Should().NotBeEmpty();
+
+            await handler.Handle(request, default);
+
+            // Post assertions
+            var deletedPenalties = await dbContext.AddPenaltys
+                .Where(x => x.ScoredResultRow.ScoredSessionResult.ScoredEventResult.EventId == TestEventId)
+                .ToListAsync();
+            deletedPenalties.Should().BeEmpty();
+            var deletedResult = await dbContext.ScoredEventResults
+                .Where(x => x.EventId == request.EventId)
+                .FirstOrDefaultAsync();
+            deletedResult.Should().BeNull();            
+        }
+    }
+}


### PR DESCRIPTION
Delete assigned penalties when clearing results.
This solves the problem where the user was unable to delete or refresh results with penalties applied.